### PR TITLE
feat(config): add tab bar color configuration options

### DIFF
--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -187,3 +187,48 @@ pub fn unfocused_fps() -> u32 {
 pub fn shader_hot_reload_delay() -> u64 {
     100 // Debounce delay in milliseconds
 }
+
+// Tab bar color defaults
+pub fn tab_bar_background() -> [u8; 3] {
+    [40, 40, 40] // Dark gray background
+}
+
+pub fn tab_active_background() -> [u8; 3] {
+    [60, 60, 60] // Slightly lighter for active tab
+}
+
+pub fn tab_inactive_background() -> [u8; 3] {
+    [40, 40, 40] // Same as bar background
+}
+
+pub fn tab_hover_background() -> [u8; 3] {
+    [50, 50, 50] // Between inactive and active
+}
+
+pub fn tab_active_text() -> [u8; 3] {
+    [255, 255, 255] // White text for active tab
+}
+
+pub fn tab_inactive_text() -> [u8; 3] {
+    [180, 180, 180] // Gray text for inactive tabs
+}
+
+pub fn tab_active_indicator() -> [u8; 3] {
+    [100, 150, 255] // Blue underline for active tab
+}
+
+pub fn tab_activity_indicator() -> [u8; 3] {
+    [100, 180, 255] // Light blue activity dot
+}
+
+pub fn tab_bell_indicator() -> [u8; 3] {
+    [255, 200, 100] // Orange/yellow bell icon
+}
+
+pub fn tab_close_button() -> [u8; 3] {
+    [150, 150, 150] // Gray close button
+}
+
+pub fn tab_close_button_hover() -> [u8; 3] {
+    [255, 100, 100] // Red on hover
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -455,6 +455,53 @@ pub struct Config {
     pub max_tabs: usize,
 
     // ========================================================================
+    // Tab Bar Colors
+    // ========================================================================
+    /// Tab bar background color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_bar_background")]
+    pub tab_bar_background: [u8; 3],
+
+    /// Active tab background color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_active_background")]
+    pub tab_active_background: [u8; 3],
+
+    /// Inactive tab background color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_inactive_background")]
+    pub tab_inactive_background: [u8; 3],
+
+    /// Hovered tab background color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_hover_background")]
+    pub tab_hover_background: [u8; 3],
+
+    /// Active tab text color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_active_text")]
+    pub tab_active_text: [u8; 3],
+
+    /// Inactive tab text color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_inactive_text")]
+    pub tab_inactive_text: [u8; 3],
+
+    /// Active tab indicator/underline color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_active_indicator")]
+    pub tab_active_indicator: [u8; 3],
+
+    /// Activity indicator dot color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_activity_indicator")]
+    pub tab_activity_indicator: [u8; 3],
+
+    /// Bell indicator color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_bell_indicator")]
+    pub tab_bell_indicator: [u8; 3],
+
+    /// Close button color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_close_button")]
+    pub tab_close_button: [u8; 3],
+
+    /// Close button hover color [R, G, B] (0-255)
+    #[serde(default = "defaults::tab_close_button_hover")]
+    pub tab_close_button_hover: [u8; 3],
+
+    // ========================================================================
     // Focus/Blur Power Saving
     // ========================================================================
     /// Pause shader animations when window loses focus
@@ -576,6 +623,17 @@ impl Default for Config {
             tab_show_index: defaults::bool_false(),
             tab_inherit_cwd: defaults::bool_true(),
             max_tabs: defaults::zero(),
+            tab_bar_background: defaults::tab_bar_background(),
+            tab_active_background: defaults::tab_active_background(),
+            tab_inactive_background: defaults::tab_inactive_background(),
+            tab_hover_background: defaults::tab_hover_background(),
+            tab_active_text: defaults::tab_active_text(),
+            tab_inactive_text: defaults::tab_inactive_text(),
+            tab_active_indicator: defaults::tab_active_indicator(),
+            tab_activity_indicator: defaults::tab_activity_indicator(),
+            tab_bell_indicator: defaults::tab_bell_indicator(),
+            tab_close_button: defaults::tab_close_button(),
+            tab_close_button_hover: defaults::tab_close_button_hover(),
             pause_shaders_on_blur: defaults::bool_true(),
             pause_refresh_on_blur: defaults::bool_false(),
             unfocused_fps: defaults::unfocused_fps(),

--- a/src/settings_ui/mod.rs
+++ b/src/settings_ui/mod.rs
@@ -19,6 +19,7 @@ mod shader_dialogs;
 mod shader_editor;
 mod shader_utils;
 pub mod shell_tab;
+pub mod tab_bar_tab;
 pub mod terminal_tab;
 pub mod theme_tab;
 pub mod window_tab;
@@ -616,6 +617,26 @@ impl SettingsUI {
             insert_section_separator(ui, &mut section_shown);
             matches_found = true;
             shell_tab::show(ui, self, changes_this_frame);
+        }
+
+        // Tab Bar
+        if section_matches(
+            "Tab Bar",
+            &[
+                "Tab bar",
+                "Tab background",
+                "Tab text",
+                "Tab indicator",
+                "Tab close",
+                "Active tab",
+                "Inactive tab",
+                "Bell",
+                "Activity",
+            ],
+        ) {
+            insert_section_separator(ui, &mut section_shown);
+            matches_found = true;
+            tab_bar_tab::show(ui, self, changes_this_frame);
         }
 
         // Screenshot

--- a/src/settings_ui/tab_bar_tab.rs
+++ b/src/settings_ui/tab_bar_tab.rs
@@ -1,0 +1,132 @@
+//! Tab bar settings UI.
+
+use super::SettingsUI;
+
+pub fn show(ui: &mut egui::Ui, settings: &mut SettingsUI, changes_this_frame: &mut bool) {
+    ui.collapsing("Tab Bar", |ui| {
+        ui.label("Background Colors");
+        ui.indent("tab_bg_colors", |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Tab bar background:");
+                let mut color = settings.config.tab_bar_background;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_bar_background = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Active tab:");
+                let mut color = settings.config.tab_active_background;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_active_background = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Inactive tab:");
+                let mut color = settings.config.tab_inactive_background;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_inactive_background = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Hovered tab:");
+                let mut color = settings.config.tab_hover_background;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_hover_background = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+        });
+
+        ui.add_space(8.0);
+        ui.label("Text Colors");
+        ui.indent("tab_text_colors", |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Active tab text:");
+                let mut color = settings.config.tab_active_text;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_active_text = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Inactive tab text:");
+                let mut color = settings.config.tab_inactive_text;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_inactive_text = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+        });
+
+        ui.add_space(8.0);
+        ui.label("Indicator Colors");
+        ui.indent("tab_indicator_colors", |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Active indicator:");
+                let mut color = settings.config.tab_active_indicator;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_active_indicator = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Activity indicator:");
+                let mut color = settings.config.tab_activity_indicator;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_activity_indicator = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Bell indicator:");
+                let mut color = settings.config.tab_bell_indicator;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_bell_indicator = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+        });
+
+        ui.add_space(8.0);
+        ui.label("Close Button Colors");
+        ui.indent("tab_close_colors", |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Close button:");
+                let mut color = settings.config.tab_close_button;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_close_button = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Close button hover:");
+                let mut color = settings.config.tab_close_button_hover;
+                if ui.color_edit_button_srgb(&mut color).changed() {
+                    settings.config.tab_close_button_hover = color;
+                    settings.has_changes = true;
+                    *changes_this_frame = true;
+                }
+            });
+        });
+    });
+}

--- a/src/tab_bar_ui.rs
+++ b/src/tab_bar_ui.rs
@@ -73,9 +73,10 @@ impl TabBarUI {
         let active_tab_id = tabs.active_tab_id();
 
         // Tab bar area at the top
+        let bar_bg = config.tab_bar_background;
         egui::TopBottomPanel::top("tab_bar")
             .exact_height(config.tab_bar_height)
-            .frame(egui::Frame::NONE.fill(egui::Color32::from_rgb(40, 40, 40)))
+            .frame(egui::Frame::NONE.fill(egui::Color32::from_rgb(bar_bg[0], bar_bg[1], bar_bg[2])))
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
                     // Style for tabs
@@ -142,11 +143,14 @@ impl TabBarUI {
 
         // Tab background color
         let bg_color = if is_active {
-            egui::Color32::from_rgb(60, 60, 60)
+            let c = config.tab_active_background;
+            egui::Color32::from_rgb(c[0], c[1], c[2])
         } else if self.hovered_tab == Some(id) {
-            egui::Color32::from_rgb(50, 50, 50)
+            let c = config.tab_hover_background;
+            egui::Color32::from_rgb(c[0], c[1], c[2])
         } else {
-            egui::Color32::from_rgb(40, 40, 40)
+            let c = config.tab_inactive_background;
+            egui::Color32::from_rgb(c[0], c[1], c[2])
         };
 
         // Tab frame - use allocate_ui_with_layout to get a proper interactive response
@@ -169,11 +173,13 @@ impl TabBarUI {
             content_ui.horizontal(|ui| {
                 // Bell indicator (takes priority over activity indicator)
                 if is_bell_active {
-                    ui.colored_label(egui::Color32::from_rgb(255, 200, 100), "🔔");
+                    let c = config.tab_bell_indicator;
+                    ui.colored_label(egui::Color32::from_rgb(c[0], c[1], c[2]), "🔔");
                     ui.add_space(4.0);
                 } else if has_activity && !is_active {
                     // Activity indicator
-                    ui.colored_label(egui::Color32::from_rgb(100, 180, 255), "•");
+                    let c = config.tab_activity_indicator;
+                    ui.colored_label(egui::Color32::from_rgb(c[0], c[1], c[2]), "•");
                     ui.add_space(4.0);
                 }
 
@@ -191,9 +197,11 @@ impl TabBarUI {
                 };
 
                 let text_color = if is_active {
-                    egui::Color32::WHITE
+                    let c = config.tab_active_text;
+                    egui::Color32::from_rgb(c[0], c[1], c[2])
                 } else {
-                    egui::Color32::from_rgb(180, 180, 180)
+                    let c = config.tab_inactive_text;
+                    egui::Color32::from_rgb(c[0], c[1], c[2])
                 };
 
                 ui.label(egui::RichText::new(&display_title).color(text_color));
@@ -203,9 +211,11 @@ impl TabBarUI {
                     // Close button
                     if config.tab_show_close_button {
                         let close_color = if self.close_hovered == Some(id) {
-                            egui::Color32::from_rgb(255, 100, 100)
+                            let c = config.tab_close_button_hover;
+                            egui::Color32::from_rgb(c[0], c[1], c[2])
                         } else {
-                            egui::Color32::from_rgb(150, 150, 150)
+                            let c = config.tab_close_button;
+                            egui::Color32::from_rgb(c[0], c[1], c[2])
                         };
 
                         let close_btn = ui.add(
@@ -244,10 +254,11 @@ impl TabBarUI {
 
         // Active tab indicator (bottom border)
         if is_active {
+            let c = config.tab_active_indicator;
             ui.painter().hline(
                 tab_rect.left()..=tab_rect.right(),
                 tab_rect.bottom() - 2.0,
-                egui::Stroke::new(2.0, egui::Color32::from_rgb(100, 150, 255)),
+                egui::Stroke::new(2.0, egui::Color32::from_rgb(c[0], c[1], c[2])),
             );
         }
 

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -159,3 +159,82 @@ fn test_config_power_saving_yaml_serialization() {
     assert!(yaml.contains("pause_refresh_on_blur: true"));
     assert!(yaml.contains("unfocused_fps: 15"));
 }
+
+#[test]
+fn test_config_tab_bar_color_defaults() {
+    let config = Config::default();
+    // Tab bar background colors
+    assert_eq!(config.tab_bar_background, [40, 40, 40]);
+    assert_eq!(config.tab_active_background, [60, 60, 60]);
+    assert_eq!(config.tab_inactive_background, [40, 40, 40]);
+    assert_eq!(config.tab_hover_background, [50, 50, 50]);
+    // Tab text colors
+    assert_eq!(config.tab_active_text, [255, 255, 255]);
+    assert_eq!(config.tab_inactive_text, [180, 180, 180]);
+    // Tab indicator colors
+    assert_eq!(config.tab_active_indicator, [100, 150, 255]);
+    assert_eq!(config.tab_activity_indicator, [100, 180, 255]);
+    assert_eq!(config.tab_bell_indicator, [255, 200, 100]);
+    // Close button colors
+    assert_eq!(config.tab_close_button, [150, 150, 150]);
+    assert_eq!(config.tab_close_button_hover, [255, 100, 100]);
+}
+
+#[test]
+fn test_config_tab_bar_color_yaml_deserialization() {
+    let yaml = r#"
+tab_bar_background: [30, 30, 30]
+tab_active_background: [80, 80, 80]
+tab_inactive_background: [35, 35, 35]
+tab_hover_background: [55, 55, 55]
+tab_active_text: [240, 240, 240]
+tab_inactive_text: [160, 160, 160]
+tab_active_indicator: [120, 170, 255]
+tab_activity_indicator: [80, 200, 255]
+tab_bell_indicator: [255, 180, 80]
+tab_close_button: [130, 130, 130]
+tab_close_button_hover: [255, 80, 80]
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(config.tab_bar_background, [30, 30, 30]);
+    assert_eq!(config.tab_active_background, [80, 80, 80]);
+    assert_eq!(config.tab_inactive_background, [35, 35, 35]);
+    assert_eq!(config.tab_hover_background, [55, 55, 55]);
+    assert_eq!(config.tab_active_text, [240, 240, 240]);
+    assert_eq!(config.tab_inactive_text, [160, 160, 160]);
+    assert_eq!(config.tab_active_indicator, [120, 170, 255]);
+    assert_eq!(config.tab_activity_indicator, [80, 200, 255]);
+    assert_eq!(config.tab_bell_indicator, [255, 180, 80]);
+    assert_eq!(config.tab_close_button, [130, 130, 130]);
+    assert_eq!(config.tab_close_button_hover, [255, 80, 80]);
+}
+
+#[test]
+fn test_config_tab_bar_color_yaml_serialization() {
+    let mut config = Config::default();
+    config.tab_bar_background = [50, 50, 50];
+    config.tab_active_indicator = [200, 100, 50];
+
+    let yaml = serde_yaml::to_string(&config).unwrap();
+    assert!(yaml.contains("tab_bar_background:"));
+    assert!(yaml.contains("- 50"));
+    assert!(yaml.contains("tab_active_indicator:"));
+    assert!(yaml.contains("- 200"));
+    assert!(yaml.contains("- 100"));
+}
+
+#[test]
+fn test_config_tab_bar_color_partial_yaml() {
+    // Test that default values are used for missing tab bar color fields
+    let yaml = r#"
+tab_bar_background: [25, 25, 25]
+tab_active_text: [200, 200, 200]
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(config.tab_bar_background, [25, 25, 25]);
+    assert_eq!(config.tab_active_text, [200, 200, 200]);
+    // Other fields should have defaults
+    assert_eq!(config.tab_active_background, [60, 60, 60]);
+    assert_eq!(config.tab_inactive_background, [40, 40, 40]);
+    assert_eq!(config.tab_close_button, [150, 150, 150]);
+}


### PR DESCRIPTION
## Summary
- Add 11 new configuration options to customize tab bar colors (background, text, indicators, close button)
- Implement Settings UI panel for live color editing under "Tab Bar" section
- Update `tab_bar_ui.rs` to use configurable colors instead of hardcoded values
- Add comprehensive tests for defaults and YAML serialization/deserialization

## Configuration Options Added
```yaml
# Tab bar colors
tab_bar_background: [40, 40, 40]        # Tab bar background color
tab_active_background: [60, 60, 60]     # Active tab background
tab_inactive_background: [40, 40, 40]   # Inactive tab background
tab_hover_background: [50, 50, 50]      # Hovered tab background
tab_active_text: [255, 255, 255]        # Active tab text color
tab_inactive_text: [180, 180, 180]      # Inactive tab text color
tab_active_indicator: [100, 150, 255]   # Active tab underline color
tab_activity_indicator: [100, 180, 255] # Activity dot color
tab_bell_indicator: [255, 200, 100]     # Bell icon color
tab_close_button: [150, 150, 150]       # Close button color
tab_close_button_hover: [255, 100, 100] # Close button hover color
```

## Test plan
- [x] Verify default colors match previous hardcoded values
- [x] Run `make checkall` (format, lint, test) - all pass
- [x] Verify YAML serialization/deserialization works correctly
- [x] Verify Settings UI shows Tab Bar section with color pickers
- [ ] Manual testing: open settings, modify colors, verify live preview

Closes #3