### PR TITLE
feat(tabs): add opacity dimming for inactive tabs

### DIFF
--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -240,3 +240,7 @@ pub fn tab_close_button_hover() -> [u8; 3] {
 pub fn cubemap_enabled() -> bool {
     true // Cubemap sampling enabled by default when a path is configured
 }
+
+pub fn inactive_tab_opacity() -> f32 {
+    0.6 // Default opacity for inactive tabs (60%)
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -518,6 +518,17 @@ pub struct Config {
     #[serde(default = "defaults::tab_close_button_hover")]
     pub tab_close_button_hover: [u8; 3],
 
+    /// Enable visual dimming of inactive tabs
+    /// When true, inactive tabs are rendered with reduced opacity
+    #[serde(default = "defaults::bool_true")]
+    pub dim_inactive_tabs: bool,
+
+    /// Opacity level for inactive tabs (0.0-1.0)
+    /// Only used when dim_inactive_tabs is true
+    /// Lower values make inactive tabs more transparent/dimmed
+    #[serde(default = "defaults::inactive_tab_opacity")]
+    pub inactive_tab_opacity: f32,
+
     // ========================================================================
     // Focus/Blur Power Saving
     // ========================================================================
@@ -654,6 +665,8 @@ impl Default for Config {
             tab_bell_indicator: defaults::tab_bell_indicator(),
             tab_close_button: defaults::tab_close_button(),
             tab_close_button_hover: defaults::tab_close_button_hover(),
+            dim_inactive_tabs: defaults::bool_true(),
+            inactive_tab_opacity: defaults::inactive_tab_opacity(),
             pause_shaders_on_blur: defaults::bool_true(),
             pause_refresh_on_blur: defaults::bool_false(),
             unfocused_fps: defaults::unfocused_fps(),

--- a/src/settings_ui/tab_bar_tab.rs
+++ b/src/settings_ui/tab_bar_tab.rs
@@ -4,6 +4,41 @@ use super::SettingsUI;
 
 pub fn show(ui: &mut egui::Ui, settings: &mut SettingsUI, changes_this_frame: &mut bool) {
     ui.collapsing("Tab Bar", |ui| {
+        // Inactive Tab Dimming section
+        ui.label("Inactive Tab Dimming");
+        ui.indent("tab_dimming", |ui| {
+            if ui
+                .checkbox(&mut settings.config.dim_inactive_tabs, "Dim inactive tabs")
+                .changed()
+            {
+                settings.has_changes = true;
+                *changes_this_frame = true;
+            }
+
+            if settings.config.dim_inactive_tabs {
+                ui.horizontal(|ui| {
+                    ui.label("Opacity:");
+                    if ui
+                        .add(
+                            egui::Slider::new(&mut settings.config.inactive_tab_opacity, 0.2..=1.0)
+                                .step_by(0.05)
+                                .suffix(""),
+                        )
+                        .changed()
+                    {
+                        settings.has_changes = true;
+                        *changes_this_frame = true;
+                    }
+                });
+                ui.label(
+                    egui::RichText::new("Hovered tabs temporarily restore full opacity")
+                        .small()
+                        .weak(),
+                );
+            }
+        });
+
+        ui.add_space(8.0);
         ui.label("Background Colors");
         ui.indent("tab_bg_colors", |ui| {
             ui.horizontal(|ui| {

--- a/src/tab_bar_ui.rs
+++ b/src/tab_bar_ui.rs
@@ -141,16 +141,26 @@ impl TabBarUI {
         let tab_count = 10; // estimate
         let tab_width = (available_width / tab_count as f32).clamp(80.0, 200.0);
 
-        // Tab background color
+        // Determine if this tab should be dimmed
+        // Active tabs and hovered inactive tabs are NOT dimmed
+        let is_hovered = self.hovered_tab == Some(id);
+        let should_dim = config.dim_inactive_tabs && !is_active && !is_hovered;
+        let opacity = if should_dim {
+            (config.inactive_tab_opacity * 255.0) as u8
+        } else {
+            255
+        };
+
+        // Tab background color with opacity
         let bg_color = if is_active {
             let c = config.tab_active_background;
-            egui::Color32::from_rgb(c[0], c[1], c[2])
-        } else if self.hovered_tab == Some(id) {
+            egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], 255)
+        } else if is_hovered {
             let c = config.tab_hover_background;
-            egui::Color32::from_rgb(c[0], c[1], c[2])
+            egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], 255)
         } else {
             let c = config.tab_inactive_background;
-            egui::Color32::from_rgb(c[0], c[1], c[2])
+            egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], opacity)
         };
 
         // Tab frame - use allocate_ui_with_layout to get a proper interactive response
@@ -198,10 +208,10 @@ impl TabBarUI {
 
                 let text_color = if is_active {
                     let c = config.tab_active_text;
-                    egui::Color32::from_rgb(c[0], c[1], c[2])
+                    egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], 255)
                 } else {
                     let c = config.tab_inactive_text;
-                    egui::Color32::from_rgb(c[0], c[1], c[2])
+                    egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], opacity)
                 };
 
                 ui.label(egui::RichText::new(&display_title).color(text_color));
@@ -212,10 +222,10 @@ impl TabBarUI {
                     if config.tab_show_close_button {
                         let close_color = if self.close_hovered == Some(id) {
                             let c = config.tab_close_button_hover;
-                            egui::Color32::from_rgb(c[0], c[1], c[2])
+                            egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], 255)
                         } else {
                             let c = config.tab_close_button;
-                            egui::Color32::from_rgb(c[0], c[1], c[2])
+                            egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], opacity)
                         };
 
                         let close_btn = ui.add(

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -238,3 +238,68 @@ tab_active_text: [200, 200, 200]
     assert_eq!(config.tab_inactive_background, [40, 40, 40]);
     assert_eq!(config.tab_close_button, [150, 150, 150]);
 }
+
+#[test]
+fn test_config_inactive_tab_dimming_defaults() {
+    let config = Config::default();
+    // Default: dimming is enabled
+    assert!(config.dim_inactive_tabs);
+    // Default: 60% opacity for inactive tabs
+    assert!((config.inactive_tab_opacity - 0.6).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_config_inactive_tab_dimming_yaml_deserialization() {
+    let yaml = r#"
+dim_inactive_tabs: false
+inactive_tab_opacity: 0.8
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert!(!config.dim_inactive_tabs);
+    assert!((config.inactive_tab_opacity - 0.8).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_config_inactive_tab_dimming_yaml_serialization() {
+    let mut config = Config::default();
+    config.dim_inactive_tabs = false;
+    config.inactive_tab_opacity = 0.5;
+
+    let yaml = serde_yaml::to_string(&config).unwrap();
+    assert!(yaml.contains("dim_inactive_tabs: false"));
+    assert!(yaml.contains("inactive_tab_opacity: 0.5"));
+}
+
+#[test]
+fn test_config_inactive_tab_dimming_partial_yaml() {
+    // Test that default values are used for missing fields
+    let yaml = r#"
+dim_inactive_tabs: true
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert!(config.dim_inactive_tabs);
+    // Default opacity should be used
+    assert!((config.inactive_tab_opacity - 0.6).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_config_inactive_tab_opacity_bounds() {
+    // Test various opacity values that might be configured
+    let yaml = r#"
+inactive_tab_opacity: 0.0
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert!((config.inactive_tab_opacity).abs() < f32::EPSILON);
+
+    let yaml = r#"
+inactive_tab_opacity: 1.0
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert!((config.inactive_tab_opacity - 1.0).abs() < f32::EPSILON);
+
+    let yaml = r#"
+inactive_tab_opacity: 0.3
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert!((config.inactive_tab_opacity - 0.3).abs() < f32::EPSILON);
+}


### PR DESCRIPTION
## Summary

- Add configurable visual dimming effect for inactive tabs to improve multi-tab workflow usability
- Inactive tabs are rendered with reduced opacity, making the active tab more prominent
- Hovered inactive tabs temporarily restore full opacity for readability

## New Configuration Options

```yaml
dim_inactive_tabs: true        # Enable/disable dimming (default: true)
inactive_tab_opacity: 0.6      # Opacity level 0.0-1.0 (default: 0.6)
```

## Changes

- `src/config/defaults.rs`: Add default value function for inactive_tab_opacity (0.6)
- `src/config/mod.rs`: Add `dim_inactive_tabs` and `inactive_tab_opacity` config fields
- `src/tab_bar_ui.rs`: Apply opacity to inactive tab backgrounds, text, and close buttons
- `src/settings_ui/tab_bar_tab.rs`: Add UI controls for the new settings
- `tests/config_tests.rs`: Add tests for new config options

## Test plan

- [x] Open multiple tabs and verify active tab appears at full opacity
- [x] Verify inactive tabs appear dimmed (default 60% opacity)
- [x] Verify hovering over an inactive tab temporarily restores full opacity
- [x] Test with `dim_inactive_tabs: false` to confirm disable works
- [x] Test various `inactive_tab_opacity` values (0.3, 0.5, 0.8, 1.0)
- [x] Verify settings UI shows the new controls

Closes #15