### PR TITLE
feat(tabs): add ability to set individual tab colors

### DIFF
--- a/src/app/window_state.rs
+++ b/src/app/window_state.rs
@@ -1703,6 +1703,30 @@ impl WindowState {
                     window.request_redraw();
                 }
             }
+            TabBarAction::SetColor(id, color) => {
+                if let Some(tab) = self.tab_manager.get_tab_mut(id) {
+                    tab.set_custom_color(color);
+                    log::info!(
+                        "Set custom color for tab {}: RGB({}, {}, {})",
+                        id,
+                        color[0],
+                        color[1],
+                        color[2]
+                    );
+                }
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+            }
+            TabBarAction::ClearColor(id) => {
+                if let Some(tab) = self.tab_manager.get_tab_mut(id) {
+                    tab.clear_custom_color();
+                    log::info!("Cleared custom color for tab {}", id);
+                }
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+            }
             TabBarAction::None | TabBarAction::Reorder(_, _) => {}
         }
 

--- a/src/tab/mod.rs
+++ b/src/tab/mod.rs
@@ -45,6 +45,8 @@ pub struct Tab {
     pub refresh_task: Option<JoinHandle<()>>,
     /// Working directory when tab was created (for inheriting)
     pub working_directory: Option<String>,
+    /// Custom tab color [R, G, B] (0-255), overrides config colors when set
+    pub custom_color: Option<[u8; 3]>,
 }
 
 impl Tab {
@@ -143,6 +145,7 @@ impl Tab {
             cache: RenderCache::new(initial_opacity),
             refresh_task: None,
             working_directory: working_directory.or_else(|| config.working_directory.clone()),
+            custom_color: None,
         })
     }
 
@@ -248,6 +251,22 @@ impl Tab {
         if let Some(handle) = self.refresh_task.take() {
             handle.abort();
         }
+    }
+
+    /// Set a custom color for this tab
+    pub fn set_custom_color(&mut self, color: [u8; 3]) {
+        self.custom_color = Some(color);
+    }
+
+    /// Clear the custom color for this tab (reverts to default config colors)
+    pub fn clear_custom_color(&mut self) {
+        self.custom_color = None;
+    }
+
+    /// Check if this tab has a custom color set
+    #[allow(dead_code)]
+    pub fn has_custom_color(&self) -> bool {
+        self.custom_color.is_some()
     }
 }
 

--- a/tests/tab_color_tests.rs
+++ b/tests/tab_color_tests.rs
@@ -1,0 +1,70 @@
+//! Tests for custom tab color functionality
+
+use par_term::tab_bar_ui::TabBarAction;
+
+#[test]
+fn test_tab_bar_action_set_color() {
+    let color = [255, 128, 64];
+    let action = TabBarAction::SetColor(1, color);
+
+    match action {
+        TabBarAction::SetColor(id, c) => {
+            assert_eq!(id, 1);
+            assert_eq!(c, [255, 128, 64]);
+        }
+        _ => panic!("Expected SetColor action"),
+    }
+}
+
+#[test]
+fn test_tab_bar_action_clear_color() {
+    let action = TabBarAction::ClearColor(42);
+
+    match action {
+        TabBarAction::ClearColor(id) => {
+            assert_eq!(id, 42);
+        }
+        _ => panic!("Expected ClearColor action"),
+    }
+}
+
+#[test]
+fn test_tab_bar_action_equality() {
+    // Test SetColor equality
+    let action1 = TabBarAction::SetColor(1, [100, 150, 200]);
+    let action2 = TabBarAction::SetColor(1, [100, 150, 200]);
+    let action3 = TabBarAction::SetColor(1, [100, 150, 201]);
+    let action4 = TabBarAction::SetColor(2, [100, 150, 200]);
+
+    assert_eq!(action1, action2);
+    assert_ne!(action1, action3); // Different color
+    assert_ne!(action1, action4); // Different tab ID
+
+    // Test ClearColor equality
+    let clear1 = TabBarAction::ClearColor(1);
+    let clear2 = TabBarAction::ClearColor(1);
+    let clear3 = TabBarAction::ClearColor(2);
+
+    assert_eq!(clear1, clear2);
+    assert_ne!(clear1, clear3);
+
+    // Test different action types are not equal
+    assert_ne!(action1, clear1);
+}
+
+#[test]
+fn test_tab_bar_action_clone() {
+    let action = TabBarAction::SetColor(5, [50, 100, 150]);
+    let cloned = action.clone();
+
+    assert_eq!(action, cloned);
+}
+
+#[test]
+fn test_tab_bar_action_debug() {
+    let action = TabBarAction::SetColor(1, [255, 0, 0]);
+    let debug_str = format!("{:?}", action);
+
+    assert!(debug_str.contains("SetColor"));
+    assert!(debug_str.contains("255"));
+}


### PR DESCRIPTION
## Summary
- Add optional `custom_color` field to `Tab` struct for per-tab color override
- Add right-click context menu on tabs with color picker and preset color buttons
- Custom colors affect tab background (active, inactive, hover states)
- Custom colors also affect the active tab indicator line
- Small color indicator dot appears on inactive tabs with custom colors
- Add `SetColor` and `ClearColor` actions to `TabBarAction` enum

## Features
- **Right-click context menu**: Right-click on any tab to open a color picker dialog
- **Color picker**: Full RGB color selection with egui's color edit button
- **Preset colors**: Quick access to 7 common colors (Red, Green, Blue, Yellow, Purple, Cyan, Orange)
- **Apply/Clear/Cancel**: Apply the selected color, clear to revert to default, or cancel
- **Visual feedback**: 
  - Active tabs show the custom color as background
  - Inactive tabs show a dimmed version of the custom color
  - Hovered tabs show a lightened version
  - Active tab indicator uses a lightened version of the custom color
  - Small color dot indicator on inactive tabs with custom colors

## Test plan
- [x] All existing tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Formatting passes (`make fmt`)
- [x] New tests added for `TabBarAction::SetColor` and `TabBarAction::ClearColor`
- [ ] Manual testing: Right-click tab → Select color → Verify tab color changes
- [ ] Manual testing: Right-click tab → Clear Color → Verify tab reverts to default
- [ ] Manual testing: Verify color persists when switching between tabs
- [ ] Manual testing: Verify color indicator dot appears on inactive tabs

Closes #19