### PR TITLE
feat(keyboard): add Option key as Meta/Esc configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Option Key as Meta/Esc Configuration**: Essential feature for emacs/vim users (#23)
+  - Configure left and right Option/Alt key behavior independently
+  - Three modes: Normal (special characters), Meta (high bit), Esc (ESC prefix)
+  - Default mode is "Esc" for best terminal compatibility (M-x, M-f, M-b, etc.)
+  - New "Keyboard Input" section in Settings UI
+  - Config options: `left_option_key_mode` and `right_option_key_mode`
+
 - **Cursor Enhancements**: iTerm2-style cursor visibility improvements (#26)
   - **Cursor Guide**: Horizontal line spanning terminal width at cursor row
     - Configurable RGBA color with low default alpha

--- a/src/app/input_events.rs
+++ b/src/app/input_events.rs
@@ -9,6 +9,9 @@ use winit::keyboard::{Key, NamedKey};
 
 impl WindowState {
     pub(crate) fn handle_key_event(&mut self, event: KeyEvent, event_loop: &ActiveEventLoop) {
+        // Track Alt key press/release for Option key mode detection
+        self.input_handler.track_alt_key(&event);
+
         // Check if any UI panel is visible
         // Note: Settings are handled by standalone SettingsWindow, not embedded UI
         let any_ui_visible = self.help_ui.visible || self.clipboard_history_ui.visible;
@@ -279,6 +282,14 @@ impl WindowState {
                 log::info!("Configuration reloaded successfully");
 
                 // Apply settings that can be changed at runtime
+
+                // Update Option/Alt key modes
+                self.config.left_option_key_mode = new_config.left_option_key_mode;
+                self.config.right_option_key_mode = new_config.right_option_key_mode;
+                self.input_handler.update_option_key_modes(
+                    new_config.left_option_key_mode,
+                    new_config.right_option_key_mode,
+                );
 
                 // Update auto_copy_selection
                 self.config.auto_copy_selection = new_config.auto_copy_selection;

--- a/src/app/window_state.rs
+++ b/src/app/window_state.rs
@@ -115,11 +115,16 @@ impl WindowState {
         let keybinding_registry = KeybindingRegistry::from_config(&config.keybindings);
         let shaders_dir = Config::shaders_dir();
 
+        let mut input_handler = InputHandler::new();
+        // Initialize Option/Alt key modes from config
+        input_handler
+            .update_option_key_modes(config.left_option_key_mode, config.right_option_key_mode);
+
         Self {
             config,
             window: None,
             renderer: None,
-            input_handler: InputHandler::new(),
+            input_handler,
             runtime,
 
             tab_manager: TabManager::new(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,8 +21,8 @@ pub use shader_metadata::{
 // Re-export config types
 pub use types::{
     BackgroundImageMode, BackgroundMode, CursorShaderConfig, CursorShaderMetadata, CursorStyle,
-    FontRange, KeyBinding, ShaderConfig, ShaderMetadata, TabBarMode, UnfocusedCursorStyle,
-    VsyncMode,
+    FontRange, KeyBinding, OptionKeyMode, ShaderConfig, ShaderMetadata, TabBarMode,
+    UnfocusedCursorStyle, VsyncMode,
 };
 // KeyModifier is exported for potential future use (e.g., custom keybinding UI)
 #[allow(unused_imports)]
@@ -315,6 +315,24 @@ pub struct Config {
     /// Keeps current behavior by default for TUI compatibility
     #[serde(default = "defaults::cursor_shader_disable_in_alt_screen")]
     pub cursor_shader_disable_in_alt_screen: bool,
+
+    // ========================================================================
+    // Keyboard Input
+    // ========================================================================
+    /// Left Option key (macOS) / Left Alt key (Linux/Windows) behavior
+    /// - normal: Sends special characters (default macOS behavior)
+    /// - meta: Sets the high bit (8th bit) on the character
+    /// - esc: Sends Escape prefix before the character (most compatible for emacs/vim)
+    #[serde(default)]
+    pub left_option_key_mode: OptionKeyMode,
+
+    /// Right Option key (macOS) / Right Alt key (Linux/Windows) behavior
+    /// Can be configured independently from left Option key
+    /// - normal: Sends special characters (default macOS behavior)
+    /// - meta: Sets the high bit (8th bit) on the character
+    /// - esc: Sends Escape prefix before the character (most compatible for emacs/vim)
+    #[serde(default)]
+    pub right_option_key_mode: OptionKeyMode,
 
     // ========================================================================
     // Selection & Clipboard
@@ -743,6 +761,8 @@ impl Default for Config {
             window_title: defaults::window_title(),
             allow_title_change: defaults::bool_true(),
             theme: defaults::theme(),
+            left_option_key_mode: OptionKeyMode::default(),
+            right_option_key_mode: OptionKeyMode::default(),
             auto_copy_selection: defaults::bool_true(),
             copy_trailing_newline: defaults::bool_false(),
             middle_click_paste: defaults::bool_true(),

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -128,6 +128,27 @@ pub enum TabBarMode {
     Never,
 }
 
+/// Option/Alt key behavior mode
+///
+/// Controls what happens when Option (macOS) or Alt (Linux/Windows) key is pressed
+/// with a character key. This is essential for emacs and vim users who rely on
+/// Meta key combinations (M-x, M-f, M-b, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OptionKeyMode {
+    /// Normal - sends special characters (default macOS behavior)
+    /// Option+f → ƒ (special character)
+    Normal,
+    /// Meta - sets the high bit (8th bit) on the character
+    /// Option+f → 0xE6 (f with high bit set)
+    Meta,
+    /// Esc - sends Escape prefix before the character (most compatible)
+    /// Option+f → ESC f (escape then f)
+    /// This is the most compatible mode for terminal applications like emacs and vim
+    #[default]
+    Esc,
+}
+
 /// Font mapping for a specific Unicode range
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FontRange {

--- a/src/settings_ui/keyboard_tab.rs
+++ b/src/settings_ui/keyboard_tab.rs
@@ -1,0 +1,125 @@
+//! Keyboard input settings tab for the Settings UI.
+
+use crate::config::OptionKeyMode;
+
+use super::SettingsUI;
+
+/// Show the keyboard input settings section
+pub fn show(ui: &mut egui::Ui, settings: &mut SettingsUI, changes_this_frame: &mut bool) {
+    ui.collapsing("Keyboard Input", |ui| {
+        ui.label("Option/Alt key behavior for emacs, vim, and other terminal applications.");
+        ui.add_space(4.0);
+
+        // Left Option/Alt key mode
+        ui.horizontal(|ui| {
+            ui.label("Left Option/Alt sends:");
+            let current = settings.config.left_option_key_mode;
+            egui::ComboBox::from_id_salt("left_option_key_mode")
+                .selected_text(option_key_mode_label(current))
+                .show_ui(ui, |ui| {
+                    for mode in [
+                        OptionKeyMode::Esc,
+                        OptionKeyMode::Meta,
+                        OptionKeyMode::Normal,
+                    ] {
+                        if ui
+                            .selectable_value(
+                                &mut settings.config.left_option_key_mode,
+                                mode,
+                                option_key_mode_label(mode),
+                            )
+                            .changed()
+                        {
+                            settings.has_changes = true;
+                            *changes_this_frame = true;
+                        }
+                    }
+                });
+        });
+
+        // Description for left Option mode
+        ui.indent("left_option_desc", |ui| {
+            ui.label(
+                egui::RichText::new(option_key_mode_description(
+                    settings.config.left_option_key_mode,
+                ))
+                .weak()
+                .small(),
+            );
+        });
+
+        ui.add_space(8.0);
+
+        // Right Option/Alt key mode
+        ui.horizontal(|ui| {
+            ui.label("Right Option/Alt sends:");
+            let current = settings.config.right_option_key_mode;
+            egui::ComboBox::from_id_salt("right_option_key_mode")
+                .selected_text(option_key_mode_label(current))
+                .show_ui(ui, |ui| {
+                    for mode in [
+                        OptionKeyMode::Esc,
+                        OptionKeyMode::Meta,
+                        OptionKeyMode::Normal,
+                    ] {
+                        if ui
+                            .selectable_value(
+                                &mut settings.config.right_option_key_mode,
+                                mode,
+                                option_key_mode_label(mode),
+                            )
+                            .changed()
+                        {
+                            settings.has_changes = true;
+                            *changes_this_frame = true;
+                        }
+                    }
+                });
+        });
+
+        // Description for right Option mode
+        ui.indent("right_option_desc", |ui| {
+            ui.label(
+                egui::RichText::new(option_key_mode_description(
+                    settings.config.right_option_key_mode,
+                ))
+                .weak()
+                .small(),
+            );
+        });
+
+        ui.add_space(8.0);
+
+        // Hint about common use cases
+        ui.separator();
+        ui.label(egui::RichText::new("Tips:").strong());
+        ui.label("• Use \"Esc\" mode for emacs Meta key (M-x, M-f, M-b, etc.)");
+        ui.label("• Use \"Esc\" mode for vim Alt mappings");
+        ui.label("• Use \"Normal\" to type special characters (ƒ, ∂, ß, etc.)");
+        ui.label("• Configure left/right Option keys differently for flexibility");
+    });
+}
+
+/// Get the display label for an OptionKeyMode
+fn option_key_mode_label(mode: OptionKeyMode) -> &'static str {
+    match mode {
+        OptionKeyMode::Normal => "Normal",
+        OptionKeyMode::Meta => "Meta",
+        OptionKeyMode::Esc => "Esc (Recommended)",
+    }
+}
+
+/// Get the description for an OptionKeyMode
+fn option_key_mode_description(mode: OptionKeyMode) -> &'static str {
+    match mode {
+        OptionKeyMode::Normal => {
+            "Sends special characters (e.g., Option+f → ƒ). Default macOS behavior."
+        }
+        OptionKeyMode::Meta => {
+            "Sets high bit on character (e.g., Option+f → 0xE6). Legacy Meta key mode."
+        }
+        OptionKeyMode::Esc => {
+            "Sends Escape prefix (e.g., Option+f → ESC f). Best for emacs/vim compatibility."
+        }
+    }
+}

--- a/src/settings_ui/mod.rs
+++ b/src/settings_ui/mod.rs
@@ -13,6 +13,7 @@ mod cursor_shader_editor;
 pub mod cursor_tab;
 pub mod font_tab;
 pub mod keybindings_tab;
+pub mod keyboard_tab;
 pub mod mouse_tab;
 pub mod screenshot_tab;
 pub mod scrollbar_tab;
@@ -682,6 +683,25 @@ impl SettingsUI {
             insert_section_separator(ui, &mut section_shown);
             matches_found = true;
             keybindings_tab::show(ui, self, changes_this_frame);
+        }
+
+        // Keyboard Input (Option/Alt key behavior)
+        if section_matches(
+            "Keyboard Input",
+            &[
+                "Option key",
+                "Alt key",
+                "Meta",
+                "Esc",
+                "Escape",
+                "Emacs",
+                "Vim",
+                "Terminal input",
+            ],
+        ) {
+            insert_section_separator(ui, &mut section_shown);
+            matches_found = true;
+            keyboard_tab::show(ui, self, changes_this_frame);
         }
 
         // Window & Display

--- a/tests/input_tests.rs
+++ b/tests/input_tests.rs
@@ -5,6 +5,7 @@
 // These tests verify the InputHandler can be created and basic state management works.
 // More comprehensive testing would be done through integration tests or manual testing.
 
+use par_term::config::OptionKeyMode;
 use par_term::input::InputHandler;
 
 #[test]
@@ -21,6 +22,59 @@ fn test_input_handler_default() {
     // If we get here, the handler was created successfully
 }
 
+#[test]
+fn test_option_key_mode_default() {
+    // Test that OptionKeyMode defaults to Esc (most compatible for terminal use)
+    let handler = InputHandler::new();
+    assert_eq!(handler.left_option_key_mode, OptionKeyMode::Esc);
+    assert_eq!(handler.right_option_key_mode, OptionKeyMode::Esc);
+}
+
+#[test]
+fn test_update_option_key_modes() {
+    // Test that we can update the Option key modes
+    let mut handler = InputHandler::new();
+
+    // Update to different modes
+    handler.update_option_key_modes(OptionKeyMode::Normal, OptionKeyMode::Meta);
+
+    assert_eq!(handler.left_option_key_mode, OptionKeyMode::Normal);
+    assert_eq!(handler.right_option_key_mode, OptionKeyMode::Meta);
+}
+
+#[test]
+fn test_option_key_mode_variants() {
+    // Test that all OptionKeyMode variants are distinct
+    assert_ne!(OptionKeyMode::Normal, OptionKeyMode::Meta);
+    assert_ne!(OptionKeyMode::Normal, OptionKeyMode::Esc);
+    assert_ne!(OptionKeyMode::Meta, OptionKeyMode::Esc);
+
+    // Test that same variant equals itself
+    assert_eq!(OptionKeyMode::Normal, OptionKeyMode::Normal);
+    assert_eq!(OptionKeyMode::Meta, OptionKeyMode::Meta);
+    assert_eq!(OptionKeyMode::Esc, OptionKeyMode::Esc);
+}
+
+#[test]
+fn test_option_key_mode_serde() {
+    // Test serialization/deserialization of OptionKeyMode using YAML
+    let modes = [
+        (OptionKeyMode::Normal, "normal"),
+        (OptionKeyMode::Meta, "meta"),
+        (OptionKeyMode::Esc, "esc"),
+    ];
+
+    for (mode, expected_yaml) in modes {
+        // Test serialization
+        let yaml = serde_yaml::to_string(&mode).unwrap();
+        assert_eq!(yaml.trim(), expected_yaml);
+
+        // Test deserialization
+        let deserialized: OptionKeyMode = serde_yaml::from_str(expected_yaml).unwrap();
+        assert_eq!(deserialized, mode);
+    }
+}
+
 // Note: Testing individual key mappings requires creating actual winit KeyEvent instances,
 // which have platform-specific fields that cannot be easily mocked.
 // The keyboard input logic is tested through integration tests and manual testing.
@@ -32,5 +86,6 @@ fn test_input_handler_default() {
 // - Function keys produce correct sequences
 // - Modifier keys (Ctrl, Alt) modify the output appropriately
 // - Released keys are ignored
+// - Option key modes (Normal, Meta, Esc) transform input correctly
 //
 // These mappings are implemented in src/input.rs and verified through runtime testing.


### PR DESCRIPTION
## Summary

Add configuration options to control how the Option key (macOS) or Alt key (Linux/Windows) behaves, allowing users to choose between normal behavior, Meta (sets high bit), or Escape prefix modes.

This is an **essential feature** for emacs and vim users who rely on Meta key combinations (M-x, M-f, M-b, etc.).

## Changes

- **New OptionKeyMode enum** with three variants:
  - `Normal`: Sends special characters (e.g., Option+f → ƒ) - default macOS behavior
  - `Meta`: Sets high bit (8th bit) on character (e.g., Option+f → 0xE6) - legacy Meta mode
  - `Esc`: Sends Escape prefix (e.g., Option+f → ESC f) - most compatible for terminals

- **Independent left/right configuration**: Users can configure left and right Option/Alt keys differently for flexibility (e.g., left for Meta, right for special characters)

- **New Settings UI**: Added "Keyboard Input" section with:
  - Dropdown selectors for left and right Option/Alt key modes
  - Mode descriptions explaining each behavior
  - Tips for emacs/vim users

- **New config options**:
  ```yaml
  left_option_key_mode: esc   # esc (default), meta, or normal
  right_option_key_mode: esc  # esc (default), meta, or normal
  ```

- **Tests**: Added tests for OptionKeyMode serialization and InputHandler mode updates

## Technical Details

- Tracks Alt key press/release via physical key codes to determine which Alt (left/right) is active
- Maps physical key codes to base characters for proper Esc/Meta mode transformations
- Default mode is "Esc" for best compatibility with terminal applications

## Test Plan

- [x] `make pre-commit` passes (fmt, lint, tests)
- [x] New tests for OptionKeyMode enum and InputHandler
- [ ] Manual testing with emacs/vim to verify M-x, M-f, M-b work
- [ ] Test both left and right Option keys with different modes
- [ ] Test on macOS (Option key) and Linux (Alt key)

Closes #23