### PR TITLE
feat(font): add anti-aliasing control and thin strokes font rendering options (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Font Rendering Options**: Anti-aliasing and thin strokes controls for improved text appearance (#32)
+  - **Anti-aliasing**: Toggle font smoothing on/off for crisp or smooth text
+    - Disable for sharp, pixelated text at small sizes
+    - Config option: `font_antialias` (default: true)
+  - **Hinting**: Control font hinting for pixel-aligned glyphs
+    - Improves text clarity at small sizes by aligning to pixel boundaries
+    - Config option: `font_hinting` (default: true)
+  - **Thin Strokes Mode**: iTerm2-inspired font smoothing modes for HiDPI displays
+    - `never`: Standard stroke weight everywhere
+    - `retina_only`: Lighter strokes on HiDPI displays (default)
+    - `dark_backgrounds_only`: Lighter strokes on dark backgrounds
+    - `retina_dark_backgrounds_only`: Lighter strokes only on HiDPI + dark backgrounds
+    - `always`: Always use lighter strokes
+    - Config option: `font_thin_strokes`
+  - All options accessible in Settings > Font > Rendering Options
+  - Changes take effect immediately by clearing and re-rasterizing the glyph cache
+
 - **Activity and Idle Notifications**: Desktop notifications for terminal activity (#29)
   - **Activity notification**: Triggers when terminal output resumes after inactivity
     - Useful for alerting when long-running commands complete

--- a/src/app/renderer_init.rs
+++ b/src/app/renderer_init.rs
@@ -6,7 +6,8 @@
 
 use crate::config::{
     BackgroundImageMode, BackgroundMode, Config, CursorShaderMetadata, FontRange, ShaderMetadata,
-    UnfocusedCursorStyle, VsyncMode, resolve_cursor_shader_config, resolve_shader_config,
+    ThinStrokesMode, UnfocusedCursorStyle, VsyncMode, resolve_cursor_shader_config,
+    resolve_shader_config,
 };
 
 /// Expand tilde in path to home directory
@@ -44,6 +45,9 @@ pub(crate) struct RendererInitParams {
     pub enable_text_shaping: bool,
     pub enable_ligatures: bool,
     pub enable_kerning: bool,
+    pub font_antialias: bool,
+    pub font_hinting: bool,
+    pub font_thin_strokes: ThinStrokesMode,
     pub vsync_mode: VsyncMode,
     pub window_opacity: f32,
     /// Theme background color (used for Default mode and cell backgrounds)
@@ -149,6 +153,9 @@ impl RendererInitParams {
             enable_text_shaping: config.enable_text_shaping,
             enable_ligatures: config.enable_ligatures,
             enable_kerning: config.enable_kerning,
+            font_antialias: config.font_antialias,
+            font_hinting: config.font_hinting,
+            font_thin_strokes: config.font_thin_strokes,
             vsync_mode: config.vsync_mode,
             window_opacity: config.window_opacity,
             background_color: theme.background.as_array(),
@@ -223,6 +230,9 @@ impl RendererInitParams {
             self.enable_text_shaping,
             self.enable_ligatures,
             self.enable_kerning,
+            self.font_antialias,
+            self.font_hinting,
+            self.font_thin_strokes,
             self.vsync_mode,
             self.window_opacity,
             self.background_color,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,7 +22,7 @@ pub use shader_metadata::{
 pub use types::{
     BackgroundImageMode, BackgroundMode, CursorShaderConfig, CursorShaderMetadata, CursorStyle,
     FontRange, KeyBinding, OptionKeyMode, ShaderConfig, ShaderMetadata, TabBarMode,
-    UnfocusedCursorStyle, VsyncMode,
+    ThinStrokesMode, UnfocusedCursorStyle, VsyncMode,
 };
 // KeyModifier is exported for potential future use (e.g., custom keybinding UI)
 #[allow(unused_imports)]
@@ -99,6 +99,27 @@ pub struct Config {
     /// Enable kerning adjustments (requires enable_text_shaping)
     #[serde(default = "defaults::bool_true")]
     pub enable_kerning: bool,
+
+    /// Enable anti-aliasing for font rendering
+    /// When false, text is rendered without smoothing (aliased/pixelated)
+    #[serde(default = "defaults::bool_true")]
+    pub font_antialias: bool,
+
+    /// Enable hinting for font rendering
+    /// Hinting improves text clarity at small sizes by aligning glyphs to pixel boundaries
+    /// Disable for a softer, more "true to design" appearance
+    #[serde(default = "defaults::bool_true")]
+    pub font_hinting: bool,
+
+    /// Thin strokes / font smoothing mode
+    /// Controls stroke weight adjustment for improved rendering on different displays.
+    /// - never: Standard stroke weight everywhere
+    /// - retina_only: Lighter strokes on HiDPI displays (default)
+    /// - dark_backgrounds_only: Lighter strokes on dark backgrounds
+    /// - retina_dark_backgrounds_only: Lighter strokes only on HiDPI + dark backgrounds
+    /// - always: Always use lighter strokes
+    #[serde(default)]
+    pub font_thin_strokes: ThinStrokesMode,
 
     /// Window title
     #[serde(default = "defaults::window_title")]
@@ -740,6 +761,9 @@ impl Default for Config {
             enable_text_shaping: defaults::text_shaping(),
             enable_ligatures: defaults::bool_true(),
             enable_kerning: defaults::bool_true(),
+            font_antialias: defaults::bool_true(),
+            font_hinting: defaults::bool_true(),
+            font_thin_strokes: ThinStrokesMode::default(),
             scrollback_lines: defaults::scrollback(),
             cursor_blink: defaults::bool_false(),
             cursor_blink_interval: defaults::cursor_blink_interval(),

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -160,6 +160,26 @@ pub struct FontRange {
     pub font_family: String,
 }
 
+/// Thin strokes / font smoothing mode
+///
+/// Controls font stroke weight adjustment for improved rendering,
+/// particularly on high-DPI/Retina displays. Inspired by iTerm2's thin strokes feature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinStrokesMode {
+    /// Never apply thin strokes
+    Never,
+    /// Apply thin strokes only on Retina/HiDPI displays (default)
+    #[default]
+    RetinaOnly,
+    /// Apply thin strokes only on dark backgrounds
+    DarkBackgroundsOnly,
+    /// Apply thin strokes only on Retina displays with dark backgrounds
+    RetinaDarkBackgroundsOnly,
+    /// Always apply thin strokes
+    Always,
+}
+
 // ============================================================================
 // Per-Shader Configuration Types
 // ============================================================================

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -70,6 +70,9 @@ impl Renderer {
         enable_text_shaping: bool,
         enable_ligatures: bool,
         enable_kerning: bool,
+        font_antialias: bool,
+        font_hinting: bool,
+        font_thin_strokes: crate::config::ThinStrokesMode,
         vsync_mode: crate::config::VsyncMode,
         window_opacity: f32,
         background_color: [u8; 3],
@@ -172,6 +175,9 @@ impl Renderer {
             enable_text_shaping,
             enable_ligatures,
             enable_kerning,
+            font_antialias,
+            font_hinting,
+            font_thin_strokes,
             vsync_mode,
             window_opacity,
             background_color,
@@ -1034,6 +1040,36 @@ impl Renderer {
     pub fn clear_glyph_cache(&mut self) {
         self.cell_renderer.clear_glyph_cache();
         self.dirty = true;
+    }
+
+    /// Update font anti-aliasing setting
+    /// Returns true if the setting changed (requiring glyph cache clear)
+    pub fn update_font_antialias(&mut self, enabled: bool) -> bool {
+        let changed = self.cell_renderer.update_font_antialias(enabled);
+        if changed {
+            self.dirty = true;
+        }
+        changed
+    }
+
+    /// Update font hinting setting
+    /// Returns true if the setting changed (requiring glyph cache clear)
+    pub fn update_font_hinting(&mut self, enabled: bool) -> bool {
+        let changed = self.cell_renderer.update_font_hinting(enabled);
+        if changed {
+            self.dirty = true;
+        }
+        changed
+    }
+
+    /// Update thin strokes mode
+    /// Returns true if the setting changed (requiring glyph cache clear)
+    pub fn update_font_thin_strokes(&mut self, mode: crate::config::ThinStrokesMode) -> bool {
+        let changed = self.cell_renderer.update_font_thin_strokes(mode);
+        if changed {
+            self.dirty = true;
+        }
+        changed
     }
 
     /// Pause shader animations (e.g., when window loses focus)

--- a/src/settings_ui/font_tab.rs
+++ b/src/settings_ui/font_tab.rs
@@ -1,4 +1,5 @@
 use super::SettingsUI;
+use crate::config::ThinStrokesMode;
 
 pub fn show(ui: &mut egui::Ui, settings: &mut SettingsUI, changes_this_frame: &mut bool) {
     ui.collapsing("Font", |ui| {
@@ -101,6 +102,92 @@ pub fn show(ui: &mut egui::Ui, settings: &mut SettingsUI, changes_this_frame: &m
         {
             settings.font_pending_changes = true;
         }
+
+        ui.separator();
+        ui.label("Rendering Options");
+
+        if ui
+            .checkbox(
+                &mut settings.config.font_antialias,
+                "Anti-aliasing",
+            )
+            .on_hover_text("Enable smooth font edges. Disable for crisp, pixelated text.")
+            .changed()
+        {
+            settings.has_changes = true;
+            *changes_this_frame = true;
+        }
+
+        if ui
+            .checkbox(
+                &mut settings.config.font_hinting,
+                "Hinting",
+            )
+            .on_hover_text("Align glyphs to pixel boundaries for sharper text at small sizes.")
+            .changed()
+        {
+            settings.has_changes = true;
+            *changes_this_frame = true;
+        }
+
+        ui.horizontal(|ui| {
+            ui.label("Thin strokes:");
+            let current_mode = settings.config.font_thin_strokes;
+            let mode_label = match current_mode {
+                ThinStrokesMode::Never => "Never",
+                ThinStrokesMode::RetinaOnly => "Retina Only",
+                ThinStrokesMode::DarkBackgroundsOnly => "Dark Backgrounds Only",
+                ThinStrokesMode::RetinaDarkBackgroundsOnly => "Retina + Dark BG",
+                ThinStrokesMode::Always => "Always",
+            };
+
+            egui::ComboBox::from_id_salt("thin_strokes_mode")
+                .selected_text(mode_label)
+                .show_ui(ui, |ui| {
+                    if ui.selectable_label(
+                        current_mode == ThinStrokesMode::Never,
+                        "Never",
+                    ).clicked() {
+                        settings.config.font_thin_strokes = ThinStrokesMode::Never;
+                        settings.has_changes = true;
+                        *changes_this_frame = true;
+                    }
+                    if ui.selectable_label(
+                        current_mode == ThinStrokesMode::RetinaOnly,
+                        "Retina Only",
+                    ).clicked() {
+                        settings.config.font_thin_strokes = ThinStrokesMode::RetinaOnly;
+                        settings.has_changes = true;
+                        *changes_this_frame = true;
+                    }
+                    if ui.selectable_label(
+                        current_mode == ThinStrokesMode::DarkBackgroundsOnly,
+                        "Dark Backgrounds Only",
+                    ).clicked() {
+                        settings.config.font_thin_strokes = ThinStrokesMode::DarkBackgroundsOnly;
+                        settings.has_changes = true;
+                        *changes_this_frame = true;
+                    }
+                    if ui.selectable_label(
+                        current_mode == ThinStrokesMode::RetinaDarkBackgroundsOnly,
+                        "Retina + Dark BG",
+                    ).clicked() {
+                        settings.config.font_thin_strokes = ThinStrokesMode::RetinaDarkBackgroundsOnly;
+                        settings.has_changes = true;
+                        *changes_this_frame = true;
+                    }
+                    if ui.selectable_label(
+                        current_mode == ThinStrokesMode::Always,
+                        "Always",
+                    ).clicked() {
+                        settings.config.font_thin_strokes = ThinStrokesMode::Always;
+                        settings.has_changes = true;
+                        *changes_this_frame = true;
+                    }
+                });
+        });
+        ui.label("  Lighter font strokes for improved readability on HiDPI displays.")
+            .on_hover_text("Similar to macOS font smoothing. Works best on Retina/HiDPI displays with dark backgrounds.");
 
         ui.horizontal(|ui| {
             if ui.button("Apply font changes").clicked() {

--- a/src/settings_ui/mod.rs
+++ b/src/settings_ui/mod.rs
@@ -775,6 +775,12 @@ impl SettingsUI {
                 "Text shaping",
                 "Ligatures",
                 "Kerning",
+                "Anti-aliasing",
+                "Antialias",
+                "Hinting",
+                "Thin strokes",
+                "Retina",
+                "Font smoothing",
             ],
         ) {
             insert_section_separator(ui, &mut section_shown);


### PR DESCRIPTION
## Summary

Adds font rendering options for anti-aliasing control and thin strokes to improve text appearance, particularly on high-DPI/Retina displays. This addresses issue #32.

### New Configuration Options

- **`font_antialias`** (default: `true`): Toggle anti-aliasing for smooth/crisp text
- **`font_hinting`** (default: `true`): Toggle hinting for pixel-aligned glyphs  
- **`font_thin_strokes`** (default: `retina_only`): Five modes for font smoothing:
  - `never`: Standard stroke weight everywhere
  - `retina_only`: Lighter strokes on HiDPI displays (default)
  - `dark_backgrounds_only`: Lighter strokes on dark backgrounds
  - `retina_dark_backgrounds_only`: Both conditions required
  - `always`: Always use lighter strokes

### Implementation Details

- Added `ThinStrokesMode` enum to `src/config/types.rs`
- Added new config fields to `src/config/mod.rs`
- Updated `CellRenderer` to store and apply font rendering settings
- Modified `atlas.rs` to use swash's `hint()` and `format()` options:
  - Respects hinting setting via `scaler.hint()`
  - Uses subpixel rendering format for thin strokes effect
  - Thresholds alpha values when anti-aliasing is disabled
- Added Settings UI controls in Font tab with dropdown for thin strokes mode
- Changes take effect immediately by clearing and re-rasterizing the glyph cache

### Inspired By

This feature is inspired by iTerm2's font rendering options, which include separate ASCII/Non-ASCII anti-aliasing and thin strokes modes. The implementation uses pure Rust (swash) rather than platform-specific APIs.

## Test plan

- [ ] Build and run with `cargo run`
- [ ] Toggle anti-aliasing and verify text appearance changes
- [ ] Toggle hinting and verify text sharpness changes
- [ ] Test each thin strokes mode and verify behavior:
  - [ ] `never` - standard weight
  - [ ] `retina_only` - lighter on HiDPI
  - [ ] `dark_backgrounds_only` - lighter on dark themes
  - [ ] `always` - consistently lighter
- [ ] Verify settings persist after restart
- [ ] Verify glyph cache clears when settings change

Closes #32