### PR TITLE
feat(search): add terminal search with scrollback support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Terminal Search** (Cmd/Ctrl+F): Search through scrollback buffer with match highlighting (#24)
+  - egui-based search bar overlay with real-time incremental search
+  - Match highlighting with configurable colors for regular and current match
+  - Navigation between matches with Enter/Shift+Enter or Cmd/Ctrl+G
+  - Search options: case sensitive (Aa), regex mode (.*), whole word (\b)
+  - Automatic scroll to current match with match counter display
+  - Debounced search (150ms) for responsive typing
+  - Proper Unicode support: correctly handles multi-byte characters (emoji, CJK)
+  - New config options: `search_highlight_color`, `search_current_highlight_color`
+  - Keyboard shortcuts: Cmd/Ctrl+F (open), Escape (close), Enter (next), Shift+Enter (prev)
+
 - **Automatic Update Checking**: Configurable update check frequency with desktop notifications (#34)
   - Check for new par-term releases from GitHub automatically
   - Four frequency options: Never, Daily, Weekly (default), Monthly
@@ -414,7 +425,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dynamic font hot-reloading
 - Font subsetting for large CJK fonts
 - Split pane support (horizontal/vertical)
-- Search functionality (Ctrl+F)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "par-term-emu-core-rust"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d407a3358d514a599c4db83fc7a4a0d4c2bf9699a671076e026eac253eecf519"
+checksum = "190c80cc69aba96b557e385f4fec0c22736666f480badfeee66fd47369921fcd"
 dependencies = [
  "base64",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 
 [dependencies]
 # Terminal emulator core
-par-term-emu-core-rust = { version = "0.22.0", default-features = false }
+par-term-emu-core-rust = { version = "0.22.1", default-features = false }
 
 # Window management and rendering
 winit = "0.30"

--- a/MATRIX.md
+++ b/MATRIX.md
@@ -442,7 +442,7 @@ Full tmux control mode integration would require:
 | Browser profile | ✅ | ❌ | ❌ | ⭐ | 🔴 | Web browser integration |
 | Progress bar | ✅ | ❌ | ❌ | ⭐⭐ | 🟡 | Show command progress |
 | Snippets | ✅ | ❌ | ❌ | ⭐⭐ | 🟡 | Saved text snippets |
-| Search in terminal | ✅ Cmd+F | ❌ | ❌ | ⭐⭐⭐ | 🟡 | Find text in scrollback |
+| Search in terminal | ✅ Cmd+F | ✅ Cmd/Ctrl+F | ✅ | - | - | Regex, case, whole word options |
 | CLI command (`par-term`) | ❌ | ✅ Full CLI | ✅ | - | - | par-term exclusive |
 | First-run shader install prompt | ❌ | ✅ Auto-detect & install | ✅ | - | - | par-term exclusive |
 | Shader gallery | ❌ | ✅ Online gallery | ✅ | - | - | par-term exclusive |
@@ -480,7 +480,6 @@ Full tmux control mode integration would require:
 3. **Split panes** - Divide terminal - 🔵 Very high effort
 4. **Shell integration** - Command tracking - 🔵 Very high effort
 5. **tmux control mode** - Native tmux integration (not basic compatibility) - 🔵 Very high effort
-6. **Search in terminal** - Find in scrollback - 🟡 Medium effort
 
 ### Recommended Implementation Priority
 
@@ -496,8 +495,7 @@ Full tmux control mode integration would require:
 9. Tab index number rendering (⭐⭐, 🟢) - config exists, just needs rendering
 
 **Phase 2 - Medium Effort, High Value**
-1. Search in terminal (⭐⭐⭐, 🟡)
-2. Tab bar position options (⭐⭐, 🟡)
+1. Tab bar position options (⭐⭐, 🟡)
 3. Light/Dark mode theme switching (⭐⭐, 🟡)
 4. Minimum contrast (⭐⭐, 🟡)
 5. Timestamps in scrollback (⭐⭐, 🟡)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,6 +24,7 @@ mod notifications;
 pub mod render_cache;
 pub mod renderer_init;
 pub mod scroll_ops;
+pub mod search_highlight;
 pub mod tab_ops;
 pub mod text_selection;
 pub mod url_hover;

--- a/src/app/search_highlight.rs
+++ b/src/app/search_highlight.rs
@@ -1,0 +1,176 @@
+//! Search highlighting functionality for terminal cells.
+
+use crate::app::window_state::WindowState;
+use crate::cell_renderer::Cell;
+
+impl WindowState {
+    /// Apply search highlighting to cells that contain matches.
+    ///
+    /// # Arguments
+    /// * `cells` - The visible cells to modify
+    /// * `cols` - Number of columns in the terminal
+    /// * `scroll_offset` - Current scroll position (0 = at bottom)
+    /// * `scrollback_len` - Total scrollback length
+    /// * `visible_lines` - Number of visible terminal rows
+    pub(crate) fn apply_search_highlights(
+        &self,
+        cells: &mut [Cell],
+        cols: usize,
+        scroll_offset: usize,
+        scrollback_len: usize,
+        visible_lines: usize,
+    ) {
+        let matches = self.search_ui.matches();
+        if matches.is_empty() {
+            return;
+        }
+
+        let current_match_idx = self.search_ui.current_match_index();
+        let highlight_color = self.config.search_highlight_color;
+        let current_highlight_color = self.config.search_current_highlight_color;
+
+        // Calculate the range of absolute lines that are currently visible
+        // scroll_offset = 0 means we're at the bottom (most recent content)
+        // scroll_offset = scrollback_len means we're at the top
+        let total_lines = scrollback_len + visible_lines;
+        let visible_end = total_lines.saturating_sub(scroll_offset);
+        let visible_start = visible_end.saturating_sub(visible_lines);
+
+        log::trace!(
+            "Search highlight: scroll_offset={}, scrollback_len={}, visible_lines={}, total_lines={}, visible_range={}..{}",
+            scroll_offset,
+            scrollback_len,
+            visible_lines,
+            total_lines,
+            visible_start,
+            visible_end
+        );
+
+        for (match_idx, search_match) in matches.iter().enumerate() {
+            // Check if this match is in the visible range
+            if search_match.line < visible_start || search_match.line >= visible_end {
+                continue;
+            }
+
+            // Convert absolute line to viewport row
+            let viewport_row = search_match.line - visible_start;
+
+            // Determine which highlight color to use
+            let color = if match_idx == current_match_idx {
+                current_highlight_color
+            } else {
+                highlight_color
+            };
+
+            // Apply highlighting to each character in the match
+            for offset in 0..search_match.length {
+                let col = search_match.column + offset;
+                if col >= cols {
+                    break; // Match extends beyond visible columns
+                }
+
+                let cell_idx = viewport_row * cols + col;
+                if cell_idx < cells.len() {
+                    // Set background color to highlight color
+                    cells[cell_idx].bg_color = color;
+                    // Keep text visible - if bg is bright, might want to adjust fg
+                    // For now, leave fg color as-is since our highlight colors have transparency
+                }
+            }
+        }
+    }
+}
+
+/// Get the current screen lines as strings (the visible terminal content, not scrollback).
+///
+/// # Arguments
+/// * `term` - The terminal manager
+/// * `visible_lines` - Number of visible terminal rows
+pub fn get_current_screen_lines(
+    term: &crate::terminal::TerminalManager,
+    visible_lines: usize,
+) -> Vec<String> {
+    // Get cells with scroll_offset=0 to get current screen content
+    let cells = term.get_cells_with_scrollback(0, None, false, None);
+
+    // Convert cells to lines
+    let cols = term.dimensions().0;
+    cells_to_lines(&cells, cols, visible_lines)
+}
+
+/// Get all searchable lines (scrollback + current screen) as an iterator of (line_index, line_text).
+///
+/// This function ensures consistent handling of wide characters by converting all content
+/// from cells rather than using pre-built scrollback strings.
+///
+/// # Arguments
+/// * `term` - The terminal manager
+/// * `visible_lines` - Number of visible terminal rows
+///
+/// # Returns
+/// Iterator of (absolute_line_index, line_text) pairs where line 0 is the oldest scrollback line.
+pub fn get_all_searchable_lines(
+    term: &crate::terminal::TerminalManager,
+    visible_lines: usize,
+) -> impl Iterator<Item = (usize, String)> {
+    let cols = term.dimensions().0;
+    let scrollback_len = term.scrollback_len();
+
+    // Get scrollback lines from their cell representation
+    let scrollback_lines = term.scrollback_as_cells();
+    let scrollback_iter = scrollback_lines
+        .into_iter()
+        .enumerate()
+        .map(move |(idx, cells)| {
+            let line = cells_row_to_string(&cells, cols);
+            (idx, line)
+        });
+
+    // Get current screen lines
+    let screen_cells = term.get_cells_with_scrollback(0, None, false, None);
+    let current_lines = cells_to_lines(&screen_cells, cols, visible_lines);
+    let current_iter = current_lines
+        .into_iter()
+        .enumerate()
+        .map(move |(idx, line)| (scrollback_len + idx, line));
+
+    scrollback_iter.chain(current_iter)
+}
+
+/// Convert a flat array of cells into lines.
+fn cells_to_lines(cells: &[Cell], cols: usize, num_lines: usize) -> Vec<String> {
+    let mut lines = Vec::with_capacity(num_lines);
+
+    for row in 0..num_lines {
+        let row_start = row * cols;
+        let row_end = (row_start + cols).min(cells.len());
+
+        if row_start >= cells.len() {
+            lines.push(String::new());
+            continue;
+        }
+
+        let line = cells_row_to_string(&cells[row_start..row_end], cols);
+        lines.push(line);
+    }
+
+    lines
+}
+
+/// Convert a row of cells to a string for searching.
+/// Wide character spacers are converted to spaces to maintain cell index alignment.
+fn cells_row_to_string(cells: &[Cell], _cols: usize) -> String {
+    let line: String = cells
+        .iter()
+        .map(|cell| {
+            if cell.grapheme.is_empty() || cell.wide_char_spacer {
+                ' '
+            } else {
+                cell.grapheme.chars().next().unwrap_or(' ')
+            }
+        })
+        .collect();
+
+    // Trim trailing whitespace but keep the line
+    line.trim_end().to_string()
+}

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -302,3 +302,12 @@ pub fn cursor_boost_color() -> [u8; 3] {
 pub fn update_check_frequency() -> super::types::UpdateCheckFrequency {
     super::types::UpdateCheckFrequency::Weekly
 }
+
+// Search defaults
+pub fn search_highlight_color() -> [u8; 4] {
+    [255, 200, 0, 180] // Yellow with some transparency
+}
+
+pub fn search_current_highlight_color() -> [u8; 4] {
+    [255, 100, 0, 220] // Orange, more visible for current match
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -776,6 +776,29 @@ pub struct Config {
     /// Last version we notified the user about (prevents repeat notifications)
     #[serde(default)]
     pub last_notified_version: Option<String>,
+
+    // ========================================================================
+    // Search Settings
+    // ========================================================================
+    /// Highlight color for search matches [R, G, B, A] (0-255)
+    #[serde(default = "defaults::search_highlight_color")]
+    pub search_highlight_color: [u8; 4],
+
+    /// Highlight color for the current/active search match [R, G, B, A] (0-255)
+    #[serde(default = "defaults::search_current_highlight_color")]
+    pub search_current_highlight_color: [u8; 4],
+
+    /// Default case sensitivity for search
+    #[serde(default = "defaults::bool_false")]
+    pub search_case_sensitive: bool,
+
+    /// Default regex mode for search
+    #[serde(default = "defaults::bool_false")]
+    pub search_regex: bool,
+
+    /// Wrap around when navigating search matches
+    #[serde(default = "defaults::bool_true")]
+    pub search_wrap_around: bool,
 }
 
 impl Default for Config {
@@ -922,6 +945,11 @@ impl Default for Config {
             last_update_check: None,
             skipped_version: None,
             last_notified_version: None,
+            search_highlight_color: defaults::search_highlight_color(),
+            search_current_highlight_color: defaults::search_current_highlight_color(),
+            search_case_sensitive: defaults::bool_false(),
+            search_regex: defaults::bool_false(),
+            search_wrap_around: defaults::bool_true(),
         }
     }
 }

--- a/src/help_ui.rs
+++ b/src/help_ui.rs
@@ -167,6 +167,17 @@ impl HelpUI {
 
                             ui.end_row();
 
+                            // Search
+                            ui.label(RichText::new("Search").strong().underline());
+                            ui.end_row();
+
+                            shortcut_row(ui, "Cmd/Ctrl+F", "Open search");
+                            shortcut_row(ui, "Enter", "Find next match");
+                            shortcut_row(ui, "Shift+Enter", "Find previous match");
+                            shortcut_row(ui, "Escape", "Close search");
+
+                            ui.end_row();
+
                             // Terminal
                             ui.label(RichText::new("Terminal").strong().underline());
                             ui.end_row();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod menu;
 pub mod renderer;
 pub mod scroll_state;
 pub mod scrollbar;
+pub mod search;
 pub mod selection;
 pub mod settings_ui;
 pub mod settings_window;

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -1,0 +1,364 @@
+//! Search engine for terminal scrollback.
+
+use super::types::{SearchConfig, SearchMatch};
+use regex::{Regex, RegexBuilder};
+
+/// Search engine that performs text searches on terminal content.
+pub struct SearchEngine {
+    /// Cached compiled regex for the current query.
+    cached_regex: Option<(String, bool, Regex)>, // (pattern, case_sensitive, compiled)
+}
+
+impl Default for SearchEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SearchEngine {
+    /// Create a new search engine.
+    pub fn new() -> Self {
+        Self { cached_regex: None }
+    }
+
+    /// Search through lines of text and return all matches.
+    ///
+    /// # Arguments
+    /// * `lines` - Iterator of (line_index, line_text) pairs
+    /// * `query` - The search query
+    /// * `config` - Search configuration options
+    ///
+    /// # Returns
+    /// A vector of SearchMatch containing all matches found.
+    pub fn search<I>(&mut self, lines: I, query: &str, config: &SearchConfig) -> Vec<SearchMatch>
+    where
+        I: Iterator<Item = (usize, String)>,
+    {
+        if query.is_empty() {
+            return Vec::new();
+        }
+
+        let mut matches = Vec::new();
+
+        if config.use_regex {
+            self.search_regex(lines, query, config, &mut matches);
+        } else {
+            self.search_plain(lines, query, config, &mut matches);
+        }
+
+        matches
+    }
+
+    /// Perform plain text search.
+    fn search_plain<I>(
+        &self,
+        lines: I,
+        query: &str,
+        config: &SearchConfig,
+        matches: &mut Vec<SearchMatch>,
+    ) where
+        I: Iterator<Item = (usize, String)>,
+    {
+        let query_lower = if config.case_sensitive {
+            query.to_string()
+        } else {
+            query.to_lowercase()
+        };
+
+        // Query length in characters (not bytes)
+        let query_char_len = query.chars().count();
+
+        for (line_idx, line) in lines {
+            let search_line = if config.case_sensitive {
+                line.clone()
+            } else {
+                line.to_lowercase()
+            };
+
+            let mut start_byte = 0;
+            while let Some(pos) = search_line[start_byte..].find(&query_lower) {
+                let byte_offset = start_byte + pos;
+
+                // Convert byte offset to character offset for cell positioning
+                let char_column = Self::byte_offset_to_char_offset(&search_line, byte_offset);
+
+                // Check whole word matching if enabled (using byte offset for string slicing)
+                if config.whole_word
+                    && !Self::is_whole_word_static(&line, byte_offset, query_lower.len())
+                {
+                    start_byte = byte_offset + 1;
+                    continue;
+                }
+
+                matches.push(SearchMatch::new(line_idx, char_column, query_char_len));
+                start_byte = byte_offset + query_lower.len().max(1);
+
+                // Avoid infinite loops on empty matches
+                if query.is_empty() {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Perform regex search.
+    fn search_regex<I>(
+        &mut self,
+        lines: I,
+        query: &str,
+        config: &SearchConfig,
+        matches: &mut Vec<SearchMatch>,
+    ) where
+        I: Iterator<Item = (usize, String)>,
+    {
+        // Try to compile or reuse cached regex
+        let regex = match self.get_or_compile_regex(query, config.case_sensitive) {
+            Ok(re) => re.clone(), // Clone to avoid borrow issues
+            Err(e) => {
+                log::debug!("Invalid regex pattern '{}': {}", query, e);
+                return;
+            }
+        };
+
+        for (line_idx, line) in lines {
+            for mat in regex.find_iter(&line) {
+                let byte_start = mat.start();
+                let byte_end = mat.end();
+
+                // Convert byte offsets to character offsets for cell positioning
+                let char_column = Self::byte_offset_to_char_offset(&line, byte_start);
+                let char_length = Self::byte_offset_to_char_offset(&line, byte_end) - char_column;
+
+                // Check whole word matching if enabled (using byte offsets for string slicing)
+                if config.whole_word
+                    && !Self::is_whole_word_static(&line, byte_start, byte_end - byte_start)
+                {
+                    continue;
+                }
+
+                matches.push(SearchMatch::new(line_idx, char_column, char_length));
+            }
+        }
+    }
+
+    /// Convert a byte offset to a character offset in a string.
+    /// This is needed because String::find() returns byte offsets, but we need
+    /// character offsets for cell positioning (each cell = 1 character).
+    fn byte_offset_to_char_offset(s: &str, byte_offset: usize) -> usize {
+        s[..byte_offset].chars().count()
+    }
+
+    /// Get cached regex or compile a new one.
+    fn get_or_compile_regex(
+        &mut self,
+        pattern: &str,
+        case_sensitive: bool,
+    ) -> Result<&Regex, regex::Error> {
+        // Check if we have a cached regex that matches
+        let needs_recompile = match &self.cached_regex {
+            Some((cached_pattern, cached_case, _)) => {
+                cached_pattern != pattern || *cached_case != case_sensitive
+            }
+            None => true,
+        };
+
+        if needs_recompile {
+            let regex = RegexBuilder::new(pattern)
+                .case_insensitive(!case_sensitive)
+                .build()?;
+            self.cached_regex = Some((pattern.to_string(), case_sensitive, regex));
+        }
+
+        Ok(&self.cached_regex.as_ref().unwrap().2)
+    }
+
+    /// Check if a match at the given position is a whole word.
+    fn is_whole_word_static(line: &str, start: usize, length: usize) -> bool {
+        let end = start + length;
+
+        // Check character before the match
+        if start > 0
+            && let Some(c) = line[..start].chars().last()
+            && (c.is_alphanumeric() || c == '_')
+        {
+            return false;
+        }
+
+        // Check character after the match
+        if end < line.len()
+            && let Some(c) = line[end..].chars().next()
+            && (c.is_alphanumeric() || c == '_')
+        {
+            return false;
+        }
+
+        true
+    }
+
+    /// Clear the cached regex.
+    pub fn clear_cache(&mut self) {
+        self.cached_regex = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_lines<'a>(texts: &'a [&'a str]) -> impl Iterator<Item = (usize, String)> + 'a {
+        texts.iter().enumerate().map(|(i, s)| (i, s.to_string()))
+    }
+
+    #[test]
+    fn test_plain_search_case_insensitive() {
+        let mut engine = SearchEngine::new();
+        let lines: Vec<&str> = vec!["Hello World", "hello there", "HELLO WORLD"];
+        let config = SearchConfig::default();
+
+        let matches = engine.search(make_lines(&lines), "hello", &config);
+
+        assert_eq!(matches.len(), 3);
+        assert_eq!(matches[0], SearchMatch::new(0, 0, 5));
+        assert_eq!(matches[1], SearchMatch::new(1, 0, 5));
+        assert_eq!(matches[2], SearchMatch::new(2, 0, 5));
+    }
+
+    #[test]
+    fn test_plain_search_case_sensitive() {
+        let mut engine = SearchEngine::new();
+        let lines: Vec<&str> = vec!["Hello World", "hello there", "HELLO WORLD"];
+        let config = SearchConfig {
+            case_sensitive: true,
+            ..Default::default()
+        };
+
+        let matches = engine.search(make_lines(&lines), "hello", &config);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0], SearchMatch::new(1, 0, 5));
+    }
+
+    #[test]
+    fn test_plain_search_multiple_matches_per_line() {
+        let mut engine = SearchEngine::new();
+        let lines: Vec<&str> = vec!["foo bar foo baz foo"];
+        let config = SearchConfig::default();
+
+        let matches = engine.search(make_lines(&lines), "foo", &config);
+
+        assert_eq!(matches.len(), 3);
+        assert_eq!(matches[0], SearchMatch::new(0, 0, 3));
+        assert_eq!(matches[1], SearchMatch::new(0, 8, 3));
+        assert_eq!(matches[2], SearchMatch::new(0, 16, 3));
+    }
+
+    #[test]
+    fn test_whole_word_matching() {
+        let mut engine = SearchEngine::new();
+        let lines: Vec<&str> = vec!["foobar foo barfoo"];
+        let config = SearchConfig {
+            whole_word: true,
+            ..Default::default()
+        };
+
+        let matches = engine.search(make_lines(&lines), "foo", &config);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0], SearchMatch::new(0, 7, 3));
+    }
+
+    #[test]
+    fn test_regex_search() {
+        let mut engine = SearchEngine::new();
+        let lines: Vec<&str> = vec![
+            "error: something failed",
+            "warning: check this",
+            "error: again",
+        ];
+        let config = SearchConfig {
+            use_regex: true,
+            ..Default::default()
+        };
+
+        let matches = engine.search(make_lines(&lines), "error:", &config);
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0], SearchMatch::new(0, 0, 6));
+        assert_eq!(matches[1], SearchMatch::new(2, 0, 6));
+    }
+
+    #[test]
+    fn test_regex_pattern() {
+        let mut engine = SearchEngine::new();
+        let lines: Vec<&str> = vec!["test123", "test456", "notest"];
+        let config = SearchConfig {
+            use_regex: true,
+            ..Default::default()
+        };
+
+        let matches = engine.search(make_lines(&lines), r"test\d+", &config);
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0], SearchMatch::new(0, 0, 7));
+        assert_eq!(matches[1], SearchMatch::new(1, 0, 7));
+    }
+
+    #[test]
+    fn test_empty_query() {
+        let mut engine = SearchEngine::new();
+        let lines: Vec<&str> = vec!["some text"];
+        let config = SearchConfig::default();
+
+        let matches = engine.search(make_lines(&lines), "", &config);
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_unicode_character_offsets() {
+        let mut engine = SearchEngine::new();
+        // Emoji folder icon (4 bytes in UTF-8) followed by space and text
+        let lines: Vec<&str> = vec!["📁 Downloads", "normal text"];
+        let config = SearchConfig::default();
+
+        let matches = engine.search(make_lines(&lines), "down", &config);
+
+        // "down" should be found at character position 2 (after "📁 ")
+        // NOT byte position 5 (4 bytes for emoji + 1 for space)
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].line, 0);
+        assert_eq!(matches[0].column, 2); // Character offset, not byte offset
+        assert_eq!(matches[0].length, 4);
+    }
+
+    #[test]
+    fn test_unicode_multiple_emoji() {
+        let mut engine = SearchEngine::new();
+        // Multiple emoji before the search term
+        let lines: Vec<&str> = vec!["🎉🎊🎁 party time"];
+        let config = SearchConfig::default();
+
+        let matches = engine.search(make_lines(&lines), "party", &config);
+
+        // "party" starts at character 4 (3 emoji + 1 space)
+        // NOT byte position 13 (3*4 bytes + 1 space)
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].column, 4);
+        assert_eq!(matches[0].length, 5);
+    }
+
+    #[test]
+    fn test_invalid_regex() {
+        let mut engine = SearchEngine::new();
+        let lines: Vec<&str> = vec!["some text"];
+        let config = SearchConfig {
+            use_regex: true,
+            ..Default::default()
+        };
+
+        // Invalid regex should return empty results
+        let matches = engine.search(make_lines(&lines), "[invalid", &config);
+
+        assert!(matches.is_empty());
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,0 +1,501 @@
+//! Terminal search functionality.
+//!
+//! This module provides search functionality for the terminal scrollback buffer,
+//! including an egui-based search bar overlay, search engine with regex support,
+//! and match highlighting.
+
+mod engine;
+pub mod types;
+
+pub use engine::SearchEngine;
+pub use types::{SearchAction, SearchConfig, SearchMatch};
+
+use egui::{Color32, Context, Frame, Key, RichText, Window, epaint::Shadow};
+use std::time::Instant;
+
+/// Search debounce delay in milliseconds.
+const SEARCH_DEBOUNCE_MS: u64 = 150;
+
+/// Search UI overlay for terminal.
+pub struct SearchUI {
+    /// Whether the search UI is currently visible.
+    pub visible: bool,
+    /// Current search query.
+    query: String,
+    /// Whether search is case-sensitive.
+    case_sensitive: bool,
+    /// Whether to use regex matching.
+    use_regex: bool,
+    /// Whether to match whole words only.
+    whole_word: bool,
+    /// All matches found.
+    matches: Vec<SearchMatch>,
+    /// Index of the currently highlighted match.
+    current_match_index: usize,
+    /// Search engine instance.
+    engine: SearchEngine,
+    /// Last time the query changed (for debouncing).
+    last_query_change: Option<Instant>,
+    /// Whether search needs to be re-run.
+    needs_search: bool,
+    /// Last query that was actually searched.
+    last_searched_query: String,
+    /// Last case sensitivity setting that was searched.
+    last_searched_case_sensitive: bool,
+    /// Last regex setting that was searched.
+    last_searched_use_regex: bool,
+    /// Last whole word setting that was searched.
+    last_searched_whole_word: bool,
+    /// Whether the text input should request focus.
+    request_focus: bool,
+    /// Regex error message (if any).
+    regex_error: Option<String>,
+}
+
+impl Default for SearchUI {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SearchUI {
+    /// Create a new search UI.
+    pub fn new() -> Self {
+        Self {
+            visible: false,
+            query: String::new(),
+            case_sensitive: false,
+            use_regex: false,
+            whole_word: false,
+            matches: Vec::new(),
+            current_match_index: 0,
+            engine: SearchEngine::new(),
+            last_query_change: None,
+            needs_search: false,
+            last_searched_query: String::new(),
+            last_searched_case_sensitive: false,
+            last_searched_use_regex: false,
+            last_searched_whole_word: false,
+            request_focus: false,
+            regex_error: None,
+        }
+    }
+
+    /// Toggle search UI visibility.
+    pub fn toggle(&mut self) {
+        self.visible = !self.visible;
+        if self.visible {
+            self.request_focus = true;
+        }
+    }
+
+    /// Open the search UI (ensuring it's visible).
+    pub fn open(&mut self) {
+        self.visible = true;
+        self.request_focus = true;
+    }
+
+    /// Close the search UI.
+    pub fn close(&mut self) {
+        self.visible = false;
+    }
+
+    /// Get the current search query.
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    /// Get all current matches.
+    pub fn matches(&self) -> &[SearchMatch] {
+        &self.matches
+    }
+
+    /// Get the current match index.
+    pub fn current_match_index(&self) -> usize {
+        self.current_match_index
+    }
+
+    /// Get the current match (if any).
+    pub fn current_match(&self) -> Option<&SearchMatch> {
+        self.matches.get(self.current_match_index)
+    }
+
+    /// Move to the next match.
+    ///
+    /// Returns the new current match if navigation succeeded.
+    pub fn next_match(&mut self) -> Option<&SearchMatch> {
+        if self.matches.is_empty() {
+            return None;
+        }
+
+        self.current_match_index = (self.current_match_index + 1) % self.matches.len();
+        self.matches.get(self.current_match_index)
+    }
+
+    /// Move to the previous match.
+    ///
+    /// Returns the new current match if navigation succeeded.
+    pub fn prev_match(&mut self) -> Option<&SearchMatch> {
+        if self.matches.is_empty() {
+            return None;
+        }
+
+        if self.current_match_index == 0 {
+            self.current_match_index = self.matches.len() - 1;
+        } else {
+            self.current_match_index -= 1;
+        }
+
+        self.matches.get(self.current_match_index)
+    }
+
+    /// Update search results with new terminal content.
+    ///
+    /// # Arguments
+    /// * `lines` - Iterator of (line_index, line_text) pairs from scrollback
+    pub fn update_search<I>(&mut self, lines: I)
+    where
+        I: Iterator<Item = (usize, String)>,
+    {
+        // Check if we need to search based on debounce timing
+        if let Some(last_change) = self.last_query_change
+            && last_change.elapsed().as_millis() < SEARCH_DEBOUNCE_MS as u128
+        {
+            return;
+        }
+
+        // Check if settings changed
+        let settings_changed = self.case_sensitive != self.last_searched_case_sensitive
+            || self.use_regex != self.last_searched_use_regex
+            || self.whole_word != self.last_searched_whole_word;
+
+        // Only re-search if query or settings changed
+        if !self.needs_search && self.query == self.last_searched_query && !settings_changed {
+            return;
+        }
+
+        self.needs_search = false;
+        self.last_searched_query = self.query.clone();
+        self.last_searched_case_sensitive = self.case_sensitive;
+        self.last_searched_use_regex = self.use_regex;
+        self.last_searched_whole_word = self.whole_word;
+        self.regex_error = None;
+
+        let config = SearchConfig {
+            case_sensitive: self.case_sensitive,
+            use_regex: self.use_regex,
+            whole_word: self.whole_word,
+            wrap_around: true,
+        };
+
+        // Validate regex before searching
+        if self.use_regex
+            && !self.query.is_empty()
+            && let Err(e) = regex::Regex::new(&self.query)
+        {
+            self.regex_error = Some(e.to_string());
+            self.matches.clear();
+            self.current_match_index = 0;
+            return;
+        }
+
+        self.matches = self.engine.search(lines, &self.query, &config);
+
+        // Reset current match index if it's out of bounds
+        if self.current_match_index >= self.matches.len() {
+            self.current_match_index = 0;
+        }
+    }
+
+    /// Clear search results.
+    pub fn clear(&mut self) {
+        self.query.clear();
+        self.matches.clear();
+        self.current_match_index = 0;
+        self.needs_search = false;
+        self.last_searched_query.clear();
+        self.regex_error = None;
+    }
+
+    /// Show the search UI and return any action to take.
+    ///
+    /// # Arguments
+    /// * `ctx` - egui Context
+    /// * `terminal_rows` - Number of visible terminal rows (for scroll calculation)
+    /// * `scrollback_len` - Total scrollback length
+    ///
+    /// # Returns
+    /// A SearchAction indicating what the caller should do.
+    pub fn show(
+        &mut self,
+        ctx: &Context,
+        terminal_rows: usize,
+        scrollback_len: usize,
+    ) -> SearchAction {
+        if !self.visible {
+            return SearchAction::None;
+        }
+
+        let mut action = SearchAction::None;
+        let mut close_requested = false;
+
+        // Ensure search bar is fully opaque regardless of terminal opacity
+        let mut style = (*ctx.style()).clone();
+        let solid_bg = Color32::from_rgba_unmultiplied(30, 30, 30, 255);
+        style.visuals.window_fill = solid_bg;
+        style.visuals.panel_fill = solid_bg;
+        style.visuals.widgets.noninteractive.bg_fill = solid_bg;
+        ctx.set_style(style);
+
+        let viewport = ctx.input(|i| i.viewport_rect());
+
+        // Position at top of window
+        let window_width = 500.0_f32.min(viewport.width() - 20.0);
+
+        Window::new("Search")
+            .title_bar(false)
+            .resizable(false)
+            .collapsible(false)
+            .fixed_size([window_width, 0.0])
+            .fixed_pos([viewport.center().x - window_width / 2.0, 10.0])
+            .frame(
+                Frame::window(&ctx.style())
+                    .fill(solid_bg)
+                    .stroke(egui::Stroke::new(1.0, Color32::from_gray(60)))
+                    .shadow(Shadow {
+                        offset: [0, 2],
+                        blur: 8,
+                        spread: 0,
+                        color: Color32::from_black_alpha(100),
+                    })
+                    .inner_margin(8.0),
+            )
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    // Search icon/label
+                    ui.label(RichText::new("Search:").strong());
+
+                    // Search text input
+                    let response = ui.add_sized(
+                        [ui.available_width() - 180.0, 20.0],
+                        egui::TextEdit::singleline(&mut self.query)
+                            .hint_text("Enter search term...")
+                            .desired_width(f32::INFINITY),
+                    );
+
+                    // Request focus when first opened
+                    if self.request_focus {
+                        response.request_focus();
+                        self.request_focus = false;
+                    }
+
+                    // Track query changes for debouncing
+                    if response.changed() {
+                        self.last_query_change = Some(Instant::now());
+                        self.needs_search = true;
+                    }
+
+                    // Handle Enter key for next match
+                    if response.lost_focus() && ui.input(|i| i.key_pressed(Key::Enter)) {
+                        let shift = ui.input(|i| i.modifiers.shift);
+                        if shift {
+                            let match_line = self.prev_match().map(|m| m.line);
+                            if let Some(line) = match_line {
+                                action = self.calculate_scroll_action(
+                                    line,
+                                    terminal_rows,
+                                    scrollback_len,
+                                );
+                            }
+                        } else {
+                            let match_line = self.next_match().map(|m| m.line);
+                            if let Some(line) = match_line {
+                                action = self.calculate_scroll_action(
+                                    line,
+                                    terminal_rows,
+                                    scrollback_len,
+                                );
+                            }
+                        }
+                        response.request_focus();
+                    }
+
+                    // Handle Escape key
+                    if ui.input(|i| i.key_pressed(Key::Escape)) {
+                        close_requested = true;
+                    }
+
+                    // Match count display
+                    let match_text = if self.matches.is_empty() {
+                        if self.query.is_empty() {
+                            String::new()
+                        } else if self.regex_error.is_some() {
+                            "Invalid".to_string()
+                        } else {
+                            "No matches".to_string()
+                        }
+                    } else {
+                        format!("{} of {}", self.current_match_index + 1, self.matches.len())
+                    };
+                    ui.label(match_text);
+
+                    // Navigation buttons
+                    ui.add_enabled_ui(!self.matches.is_empty(), |ui| {
+                        if ui
+                            .button("\u{25B2}")
+                            .on_hover_text("Previous (Shift+Enter)")
+                            .clicked()
+                        {
+                            let match_line = self.prev_match().map(|m| m.line);
+                            if let Some(line) = match_line {
+                                action = self.calculate_scroll_action(
+                                    line,
+                                    terminal_rows,
+                                    scrollback_len,
+                                );
+                            }
+                        }
+                        if ui
+                            .button("\u{25BC}")
+                            .on_hover_text("Next (Enter)")
+                            .clicked()
+                        {
+                            let match_line = self.next_match().map(|m| m.line);
+                            if let Some(line) = match_line {
+                                action = self.calculate_scroll_action(
+                                    line,
+                                    terminal_rows,
+                                    scrollback_len,
+                                );
+                            }
+                        }
+                    });
+
+                    // Close button
+                    if ui
+                        .button("\u{2715}")
+                        .on_hover_text("Close (Escape)")
+                        .clicked()
+                    {
+                        close_requested = true;
+                    }
+                });
+
+                // Second row: options
+                ui.horizontal(|ui| {
+                    // Case sensitivity toggle
+                    let case_btn = ui.selectable_label(self.case_sensitive, "Aa");
+                    if case_btn.on_hover_text("Case sensitive").clicked() {
+                        self.case_sensitive = !self.case_sensitive;
+                        self.needs_search = true;
+                    }
+
+                    // Regex toggle
+                    let regex_btn = ui.selectable_label(self.use_regex, ".*");
+                    if regex_btn.on_hover_text("Regular expression").clicked() {
+                        self.use_regex = !self.use_regex;
+                        self.needs_search = true;
+                    }
+
+                    // Whole word toggle
+                    let word_btn = ui.selectable_label(self.whole_word, "\\b");
+                    if word_btn.on_hover_text("Whole word").clicked() {
+                        self.whole_word = !self.whole_word;
+                        self.needs_search = true;
+                    }
+
+                    // Show regex error if present
+                    if let Some(ref error) = self.regex_error {
+                        ui.colored_label(
+                            Color32::from_rgb(255, 100, 100),
+                            format!("Regex error: {}", truncate_error(error, 40)),
+                        );
+                    }
+                });
+
+                // Keyboard hints
+                ui.horizontal(|ui| {
+                    ui.label(
+                        RichText::new("Enter: Next | Shift+Enter: Prev | Escape: Close")
+                            .weak()
+                            .small(),
+                    );
+                });
+            });
+
+        // Handle keyboard shortcuts outside the UI
+        let cmd_g_shift =
+            ctx.input(|i| i.modifiers.command && i.modifiers.shift && i.key_pressed(Key::G));
+        let cmd_g =
+            ctx.input(|i| i.modifiers.command && !i.modifiers.shift && i.key_pressed(Key::G));
+
+        if cmd_g_shift {
+            let match_line = self.prev_match().map(|m| m.line);
+            if let Some(line) = match_line {
+                action = self.calculate_scroll_action(line, terminal_rows, scrollback_len);
+            }
+        } else if cmd_g {
+            let match_line = self.next_match().map(|m| m.line);
+            if let Some(line) = match_line {
+                action = self.calculate_scroll_action(line, terminal_rows, scrollback_len);
+            }
+        }
+
+        if close_requested {
+            self.visible = false;
+            return SearchAction::Close;
+        }
+
+        action
+    }
+
+    /// Calculate the scroll offset needed to show a match at the given line.
+    fn calculate_scroll_action(
+        &self,
+        match_line: usize,
+        terminal_rows: usize,
+        scrollback_len: usize,
+    ) -> SearchAction {
+        // Total lines = scrollback + visible screen
+        let total_lines = scrollback_len + terminal_rows;
+
+        // Calculate scroll offset to center the match on screen
+        // scroll_offset = 0 means we're at the bottom (showing most recent content)
+        // scroll_offset = scrollback_len means we're at the top
+
+        // The match line is in terms of absolute line index (0 = oldest scrollback)
+        // We need to convert this to a scroll_offset
+
+        // If match is in the visible area at the bottom (most recent), scroll_offset = 0
+        // If match is at the very top of scrollback, scroll_offset = scrollback_len
+
+        // Calculate how far from the bottom the match line is
+        let lines_from_bottom = total_lines.saturating_sub(match_line + 1);
+
+        // We want to show the match near the center of the viewport
+        let center_offset = terminal_rows / 2;
+
+        // Scroll offset to put the match at the center
+        let target_offset = lines_from_bottom.saturating_sub(center_offset);
+
+        // Clamp to valid range
+        let clamped_offset = target_offset.min(scrollback_len);
+
+        SearchAction::ScrollToMatch(clamped_offset)
+    }
+
+    /// Initialize search settings from config.
+    pub fn init_from_config(&mut self, case_sensitive: bool, use_regex: bool) {
+        self.case_sensitive = case_sensitive;
+        self.use_regex = use_regex;
+    }
+}
+
+/// Truncate error message for display.
+fn truncate_error(error: &str, max_len: usize) -> &str {
+    if error.len() <= max_len {
+        error
+    } else {
+        &error[..max_len]
+    }
+}

--- a/src/search/types.rs
+++ b/src/search/types.rs
@@ -1,0 +1,58 @@
+//! Types for terminal search functionality.
+
+/// A single search match in the terminal scrollback.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SearchMatch {
+    /// Line index in scrollback (0 = oldest line)
+    pub line: usize,
+    /// Column position in the line (0-indexed)
+    pub column: usize,
+    /// Length of the match in characters
+    pub length: usize,
+}
+
+impl SearchMatch {
+    /// Create a new search match.
+    pub fn new(line: usize, column: usize, length: usize) -> Self {
+        Self {
+            line,
+            column,
+            length,
+        }
+    }
+}
+
+/// Configuration options for search behavior.
+#[derive(Clone, Debug)]
+pub struct SearchConfig {
+    /// Whether search is case-sensitive.
+    pub case_sensitive: bool,
+    /// Whether to use regex pattern matching.
+    pub use_regex: bool,
+    /// Whether to match whole words only.
+    pub whole_word: bool,
+    /// Whether to wrap around when navigating matches.
+    pub wrap_around: bool,
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            case_sensitive: false,
+            use_regex: false,
+            whole_word: false,
+            wrap_around: true,
+        }
+    }
+}
+
+/// Actions that can result from search UI interaction.
+#[derive(Debug, Clone)]
+pub enum SearchAction {
+    /// No action needed.
+    None,
+    /// Scroll to make a match visible at the given scroll offset.
+    ScrollToMatch(usize),
+    /// Close the search UI.
+    Close,
+}

--- a/src/settings_ui/mod.rs
+++ b/src/settings_ui/mod.rs
@@ -17,6 +17,7 @@ pub mod keyboard_tab;
 pub mod mouse_tab;
 pub mod screenshot_tab;
 pub mod scrollbar_tab;
+pub mod search_tab;
 mod shader_dialogs;
 mod shader_editor;
 mod shader_utils;
@@ -855,6 +856,23 @@ impl SettingsUI {
             insert_section_separator(ui, &mut section_shown);
             matches_found = true;
             mouse_tab::show_mouse_behavior(ui, self, changes_this_frame);
+        }
+
+        // Search
+        if section_matches(
+            "Search",
+            &[
+                "Search",
+                "Find",
+                "Highlight",
+                "Case sensitive",
+                "Regex",
+                "Wrap around",
+            ],
+        ) {
+            insert_section_separator(ui, &mut section_shown);
+            matches_found = true;
+            search_tab::show(ui, self, changes_this_frame);
         }
 
         // Scrollbar

--- a/src/settings_ui/search_tab.rs
+++ b/src/settings_ui/search_tab.rs
@@ -1,0 +1,102 @@
+//! Search settings tab for the settings UI.
+
+use super::SettingsUI;
+use egui::Color32;
+
+pub fn show(ui: &mut egui::Ui, settings: &mut SettingsUI, changes_this_frame: &mut bool) {
+    ui.collapsing("Search", |ui| {
+        ui.label("Highlight Colors");
+        ui.separator();
+
+        // Match highlight color
+        ui.horizontal(|ui| {
+            ui.label("Match highlight:");
+            let mut color = Color32::from_rgba_unmultiplied(
+                settings.config.search_highlight_color[0],
+                settings.config.search_highlight_color[1],
+                settings.config.search_highlight_color[2],
+                settings.config.search_highlight_color[3],
+            );
+            if ui.color_edit_button_srgba(&mut color).changed() {
+                settings.config.search_highlight_color =
+                    [color.r(), color.g(), color.b(), color.a()];
+                settings.has_changes = true;
+                *changes_this_frame = true;
+            }
+        });
+
+        // Current match highlight color
+        ui.horizontal(|ui| {
+            ui.label("Current match:");
+            let mut color = Color32::from_rgba_unmultiplied(
+                settings.config.search_current_highlight_color[0],
+                settings.config.search_current_highlight_color[1],
+                settings.config.search_current_highlight_color[2],
+                settings.config.search_current_highlight_color[3],
+            );
+            if ui.color_edit_button_srgba(&mut color).changed() {
+                settings.config.search_current_highlight_color =
+                    [color.r(), color.g(), color.b(), color.a()];
+                settings.has_changes = true;
+                *changes_this_frame = true;
+            }
+        });
+
+        ui.add_space(8.0);
+        ui.label("Default Options");
+        ui.separator();
+
+        // Case sensitivity default
+        if ui
+            .checkbox(
+                &mut settings.config.search_case_sensitive,
+                "Case sensitive by default",
+            )
+            .on_hover_text("When enabled, search will be case-sensitive by default")
+            .changed()
+        {
+            settings.has_changes = true;
+            *changes_this_frame = true;
+        }
+
+        // Regex default
+        if ui
+            .checkbox(&mut settings.config.search_regex, "Use regex by default")
+            .on_hover_text(
+                "When enabled, search patterns will be treated as regular expressions by default",
+            )
+            .changed()
+        {
+            settings.has_changes = true;
+            *changes_this_frame = true;
+        }
+
+        // Wrap around
+        if ui
+            .checkbox(
+                &mut settings.config.search_wrap_around,
+                "Wrap around when navigating",
+            )
+            .on_hover_text("When enabled, navigating past the last match wraps to the first match")
+            .changed()
+        {
+            settings.has_changes = true;
+            *changes_this_frame = true;
+        }
+
+        ui.add_space(8.0);
+        ui.label(egui::RichText::new("Keyboard Shortcuts:").weak().small());
+        ui.label(
+            egui::RichText::new("  Cmd/Ctrl+F: Open search")
+                .weak()
+                .small(),
+        );
+        ui.label(egui::RichText::new("  Enter: Next match").weak().small());
+        ui.label(
+            egui::RichText::new("  Shift+Enter: Previous match")
+                .weak()
+                .small(),
+        );
+        ui.label(egui::RichText::new("  Escape: Close search").weak().small());
+    });
+}


### PR DESCRIPTION
## Summary

Implements terminal search functionality (Issue #24):

- **Search UI**: egui-based search bar overlay with real-time incremental search
- **Match Highlighting**: Configurable colors for regular and current match
- **Navigation**: Enter/Shift+Enter or Cmd/Ctrl+G to move between matches
- **Search Options**: Case sensitive (Aa), regex mode (.*), whole word (\b)
- **Auto-scroll**: Automatically scrolls to show current match with counter display
- **Unicode Support**: Correctly handles multi-byte characters (emoji, CJK)

### New Config Options
- `search_highlight_color`: RGBA color for match highlighting
- `search_current_highlight_color`: RGBA color for current match

### Keyboard Shortcuts
- `Cmd/Ctrl+F`: Open search
- `Escape`: Close search
- `Enter`: Next match
- `Shift+Enter`: Previous match
- `Cmd/Ctrl+G` / `Cmd/Ctrl+Shift+G`: Next/Previous match

### Technical Details
- Updates par-term-emu-core-rust to v0.22.1 for byte-to-char offset fix
- Proper handling of UTF-8 byte offsets vs character offsets for cell positioning

## Test plan
- [x] `make pre-commit` passes
- [x] Search highlights align correctly with matched text
- [x] Unicode characters (emoji) display correct highlighting
- [x] Navigation between matches works
- [x] Regex and case-sensitive modes work