### PR TITLE
feat(shell-integration): command title, exit code badge, and remote host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Current Command in Window Title** (#94): When a command is running (via OSC 133;C shell integration), the window title bar now shows `[command_name]`. Reverts automatically when the command finishes.
+
+- **Shell Integration Badge Variables** (#94): Two new badge variables for use in badge format strings:
+  - `\(session.exit_code)` — Last command's exit code (from OSC 133;D)
+  - `\(session.current_command)` — Currently running command name (from OSC 133;C)
+  - Badge variables are also listed in the Settings UI badge tab for easy discovery.
+
+- **Remote Host Integration** (#94): Added OSC 1337 RemoteHost sequence support (via core library v0.33.0). Remote hostname and username are now synced to `session.hostname` and `session.username` badge variables from both OSC 7 file:// URLs and OSC 1337 RemoteHost sequences. Automatic profile switching based on detected hostname continues to work with both sequence types.
+
+### Changed
+
+- **Core Library**: Updated `par-term-emu-core-rust` dependency from 0.32.0 to 0.33.0 (adds OSC 1337 RemoteHost parsing).
+
 ### Fixed
 
 - **Snippet/Action Row Overflow**: Fixed Edit/Delete buttons being pushed off-screen by long command text in Snippets and Actions settings tabs. Buttons are now anchored to the right with content preview auto-truncating to fill remaining space.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3591,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "par-term-emu-core-rust"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a05e9a2358b7dd6db1e1a339fd7e11f910abb5c163c264be0ac9c5721d30df0"
+checksum = "4586c82b91024c7c175bdc85ff3ea105344827b2b2dca9b5ea22d42c536207f5"
 dependencies = [
  "base64",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ exclude = [
 ]
 
 [dependencies]
-# Terminal emulator core (with OSC 7 hostname/cwd events)
-par-term-emu-core-rust = { version = "0.32.0", default-features = false, features = ["rust-only"] }
+# Terminal emulator core (with OSC 7/1337 hostname/cwd events and RemoteHost support)
+par-term-emu-core-rust = { version = "0.33.0", default-features = false, features = ["rust-only"] }
 
 # Window management and rendering
 winit = "0.30"

--- a/MATRIX.md
+++ b/MATRIX.md
@@ -800,10 +800,10 @@ iTerm2 supports showing progress for long-running commands.
 | Shell integration version check | ✅ | ✅ Version tracking | ✅ | - | - | Tracks installed/prompted versions, prompts on update |
 | Disable shell integration | ✅ | ✅ Uninstall in Settings | ✅ | - | - | Uninstall button cleanly removes from all RC files |
 | Shell integration features | ✅ `Features` | ✅ OSC 133/7/1337 | ✅ | - | - | Partial - marks/CWD/badges |
-| Current command in window title | ✅ | ❌ | ❌ | ⭐⭐ | 🟡 | Show running command |
+| Current command in window title | ✅ | ✅ Title bar + badge var | ✅ | - | - | Shows `[cmd]` in title when running; `\(session.current_command)` badge var |
 | Command duration tracking | ✅ | ✅ Via tooltips | ✅ | - | - | Already implemented |
-| Command exit code in badge | ✅ | ❌ | ❌ | ⭐ | 🟢 | Show exit status |
-| Remote host integration | ✅ | ❌ | ❌ | ⭐⭐ | 🔴 | Remote shell integration |
+| Command exit code in badge | ✅ | ✅ Title bar + badge var | ✅ | - | - | Shows `[Exit: N]` in title on failure; `\(session.exit_code)` badge var |
+| Remote host integration | ✅ | ✅ OSC 7 + OSC 1337 RemoteHost | ✅ | - | - | Hostname/username from OSC 7 file:// URLs and OSC 1337 RemoteHost; auto profile switching |
 
 ---
 
@@ -924,13 +924,13 @@ Badges are semi-transparent text overlays displayed in the terminal corner showi
 | Browser Integration | 0 | 0 | 4 |
 | Progress Bars | 0 | 0 | 4 |
 | Advanced Paste & Input | 3 | 0 | 3 |
-| Advanced Shell Integration | 3 | 1 | 4 |
+| Advanced Shell Integration | 6 | 1 | 1 |
 | Network & Discovery | 0 | 0 | 4 |
 | Miscellaneous | 10 | 0 | 7 |
 | Badges | 9 | 0 | 0 |
-| **TOTAL** | **~275** | **~5** | **~134** |
+| **TOTAL** | **~278** | **~5** | **~131** |
 
-**Overall Parity: ~66% of iTerm2 features implemented** (273 implemented out of ~414 total tracked features)
+**Overall Parity: ~67% of iTerm2 features implemented** (276 implemented out of ~414 total tracked features)
 
 **Note: This includes many low-priority features. Core terminal functionality parity is much higher (80%+).**
 
@@ -1090,23 +1090,23 @@ The following iTerm2 features were identified and added to the matrix in this up
 - Paste as single line
 - Add/remove newlines on paste
 
-**Advanced Shell Integration (4 features)**
-- Shell integration auto-install
-- Version check and disable toggle
-- Current command in window title
-- Command exit code in badge
-- Remote host integration
+**Advanced Shell Integration (1 feature)**
+- ~~Current command in window title~~ ✅
+- ~~Command exit code in badge~~ ✅
+- ~~Remote host integration~~ ✅
 
 **Network & Discovery (4 features)**
 - Bonjour discovery
 - SSH hosts auto-discovery
 - Host profiles and quick connect
 
-**Total: 134 new features identified across 21 new categories**
+**Total: 131 new features remaining across 21 new categories**
 
 ---
 
 ### Recently Completed (v0.11.0)
+- ✅ Remote host integration: OSC 1337 RemoteHost support (core v0.33.0), hostname/username synced to badge variables
+- ✅ Shell integration title & badge: running command in window title, `\(session.exit_code)` and `\(session.current_command)` badge variables
 - ✅ Triggers & automation (regex triggers, 7 action types, coprocesses with restart policy & output viewer, Settings UI)
 - ✅ SetVariable → badge sync (trigger-captured variables displayed in badge overlay)
 - ✅ Trigger marks on scrollbar with deduplication and tooltips
@@ -1125,6 +1125,6 @@ The following iTerm2 features were identified and added to the matrix in this up
 
 ---
 
-*Updated: 2026-02-06 (Feature audit - 134 new iTerm2 features identified)*
+*Updated: 2026-02-09 (Shell integration: title, badge, remote host)*
 *iTerm2 Version: Latest (from source)*
 *par-term Version: 0.11.0+*

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ clean:
 # Install the binary
 install:
 	@echo "Installing par-term..."
-	cargo install --path .
+	cargo install --path . --bin par-term
 
 # Generate documentation
 doc:

--- a/src/settings_ui/badge_tab.rs
+++ b/src/settings_ui/badge_tab.rs
@@ -270,6 +270,8 @@ fn show_variables_section(
             ("\\(session.bell_count)", "Number of bells received"),
             ("\\(session.selection)", "Currently selected text"),
             ("\\(session.tmux_pane_title)", "tmux pane title"),
+            ("\\(session.exit_code)", "Last command exit code"),
+            ("\\(session.current_command)", "Currently running command"),
         ];
 
         // Collect clicked variable to avoid borrow issues

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -770,7 +770,6 @@ impl TerminalManager {
     }
 
     /// Get current command from shell integration
-    #[allow(dead_code)]
     pub fn shell_integration_command(&self) -> Option<String> {
         let pty = self.pty_session.lock();
         let terminal = pty.terminal();


### PR DESCRIPTION
## Summary
- Show running command name `[cmd]` in window title bar when OSC 133;C is active
- Add `\(session.exit_code)` and `\(session.current_command)` badge variables
- Sync remote hostname/username to badge variables from OSC 7 and OSC 1337 RemoteHost
- Update core library to v0.33.0 for OSC 1337 RemoteHost parsing
- Fix `make install` to only build the par-term binary

## Test plan
- [x] All 321 tests pass
- [x] Clippy clean with `-D warnings`
- [x] `make pre-commit` passes

Closes #94