### PR TITLE
feat(snippets): complete custom variables UI, key sequences, and import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Unicode Normalization**: Configurable Unicode normalization form (NFC/NFD/NFKC/NFKD/None) for text processing. NFC is the default. Exposed in Settings > Terminal > Unicode section. Live-updates across all tabs when changed.
 
+- **Snippets & Actions Completion** (#101): Complete remaining snippets and actions features
+  - **Custom Variables UI**: Collapsible editor in snippet edit form for managing per-snippet variables (name/value grid with add/delete)
+  - **Key Sequence Simulation**: `KeySequence` actions now parse and send terminal byte sequences (Ctrl combos, arrow keys, F-keys, Enter, etc.)
+  - **Snippet Import/Export**: Export all snippets to YAML file and import from YAML with duplicate detection and keybinding conflict resolution
+
 ### Fixed
 
 - **Emoji rendering**: Fixed color emoji not rendering. Swash render sources were ordered to try `Outline` first, but Apple Color Emoji on macOS has outline data that produced tiny monochrome glyphs instead of color bitmaps. Reversed source order to try `ColorBitmap` > `ColorOutline` > `Outline` so emoji fonts render as colored bitmaps while regular text fonts fall through to outlines. Also fixed TTC face index being discarded when loading fonts from fontdb.

--- a/MATRIX.md
+++ b/MATRIX.md
@@ -528,8 +528,8 @@ iTerm2 has a system for saved text snippets and custom actions.
 | Text snippets | ✅ Snippets | ✅ | ✅ | ⭐⭐ | 🟡 | Saved text blocks for quick insertion |
 | Snippet shortcuts | ✅ | ✅ | ✅ | ⭐⭐ | 🟡 | Keyboard shortcuts for snippets |
 | Snippet variables | ✅ | ✅ | ✅ | ⭐ | 🟡 | Dynamic values in snippets (10 built-in variables) |
-| Snippet library | ✅ | ✅ Partial | ✅ | ⭐⭐ | 🟡 | Organize snippets into folders (no import/export yet) |
-| Custom actions | ✅ | ✅ Partial | ✅ | ⭐ | 🔴 | Shell commands and text insertion (key sequences TODO) |
+| Snippet library | ✅ | ✅ | ✅ | ⭐⭐ | 🟡 | Organize snippets into folders, import/export YAML libraries |
+| Custom actions | ✅ | ✅ | ✅ | ⭐ | 🟡 | Shell commands, text insertion, and key sequence simulation |
 | Action key bindings | ✅ | ✅ | ✅ | ⭐ | 🟡 | Assign keys to actions via UI or config (auto-generated on load) |
 
 ### Implementation Details (v0.11.0+)
@@ -564,9 +564,10 @@ iTerm2 has a system for saved text snippets and custom actions.
 - YAML persistence via serde
 
 **Testing** (`tests/snippets_actions_tests.rs`):
-- 26 integration tests covering all major functionality
+- 50 integration tests covering all major functionality
 - Config persistence, serialization, keybinding generation
-- All 41 tests passing (26 integration + 15 unit)
+- Key sequence parsing, snippet library import/export, custom variables
+- All 67+ tests passing (50 integration + 17 parser unit)
 
 **Documentation** (`docs/SNIPPETS.md`):
 - Comprehensive user guide with examples
@@ -599,9 +600,9 @@ actions:
 
 ### Future Enhancements
 
-- [ ] Key sequence simulation (parsing and keyboard event injection)
-- [ ] Import/export snippet libraries
-- [ ] Custom variables UI editor
+- [x] Key sequence simulation (parsing and keyboard event injection)
+- [x] Import/export snippet libraries
+- [x] Custom variables UI editor
 
 ---
 
@@ -835,7 +836,7 @@ iTerm2 supports showing progress for long-running commands.
 | First-run shader install prompt | ❌ | ✅ Auto-detect & install | ✅ | - | - | par-term exclusive |
 | Shader gallery | ❌ | ✅ Online gallery | ✅ | - | - | par-term exclusive |
 | Automatic update checking | ✅ Built-in updater | ✅ `update_check_frequency` | ✅ | - | - | Notify-only (no auto-install) |
-| Quit when last session closes | ✅ | ❌ | ❌ | ⭐ | 🟢 | Auto-exit when last tab closes |
+| Quit when last session closes | ✅ | ✅ | ✅ | - | - | Already implemented - window closes when last tab closes |
 | Open files in editor | ✅ `Semantic History` | ✅ `semantic_history_*` | ✅ | - | - | Already implemented |
 | Report terminal type | ✅ | ✅ | ✅ | - | - | Already implemented |
 | Character encoding | ✅ Multiple | ✅ UTF-8 | ✅ | - | - | UTF-8 only is fine |

--- a/src/app/url_hover.rs
+++ b/src/app/url_hover.rs
@@ -80,19 +80,22 @@ impl WindowState {
                 // Sentinel for end-of-string byte positions (exclusive end)
                 byte_to_col.push(cols);
 
-                let map_byte_to_col =
-                    |byte_offset: usize| -> usize { byte_to_col.get(byte_offset).copied().unwrap_or(cols) };
+                let map_byte_to_col = |byte_offset: usize| -> usize {
+                    byte_to_col.get(byte_offset).copied().unwrap_or(cols)
+                };
 
                 // Adjust row to account for scroll offset
                 let absolute_row = row + scroll_offset;
 
                 // Detect regex-based URLs in this line and convert byte offsets to columns
                 let regex_urls = url_detection::detect_urls_in_line(&line, absolute_row);
-                tab.mouse.detected_urls.extend(regex_urls.into_iter().map(|mut url| {
-                    url.start_col = map_byte_to_col(url.start_col);
-                    url.end_col = map_byte_to_col(url.end_col);
-                    url
-                }));
+                tab.mouse
+                    .detected_urls
+                    .extend(regex_urls.into_iter().map(|mut url| {
+                        url.start_col = map_byte_to_col(url.start_col);
+                        url.end_col = map_byte_to_col(url.end_col);
+                        url
+                    }));
 
                 // Detect OSC 8 hyperlinks in this row (already use column indices)
                 let osc8_urls =
@@ -102,19 +105,21 @@ impl WindowState {
                 // Detect file paths for semantic history (if enabled)
                 if self.config.semantic_history_enabled {
                     let file_paths = url_detection::detect_file_paths_in_line(&line, absolute_row);
-                    tab.mouse.detected_urls.extend(file_paths.into_iter().map(|mut fp| {
-                        crate::debug_trace!(
-                            "SEMANTIC",
-                            "Detected path: {:?} at cols {}..{} row {}",
-                            fp.url,
-                            map_byte_to_col(fp.start_col),
-                            map_byte_to_col(fp.end_col),
-                            fp.row
-                        );
-                        fp.start_col = map_byte_to_col(fp.start_col);
-                        fp.end_col = map_byte_to_col(fp.end_col);
-                        fp
-                    }));
+                    tab.mouse
+                        .detected_urls
+                        .extend(file_paths.into_iter().map(|mut fp| {
+                            crate::debug_trace!(
+                                "SEMANTIC",
+                                "Detected path: {:?} at cols {}..{} row {}",
+                                fp.url,
+                                map_byte_to_col(fp.start_col),
+                                map_byte_to_col(fp.end_col),
+                                fp.row
+                            );
+                            fp.start_col = map_byte_to_col(fp.start_col);
+                            fp.end_col = map_byte_to_col(fp.end_col);
+                            fp
+                        }));
                 }
             }
         }

--- a/src/cell_renderer/render.rs
+++ b/src/cell_renderer/render.rs
@@ -867,8 +867,7 @@ impl CellRenderer {
                                     + self.content_offset_y
                                     + row as f32 * self.cell_height);
                             let glyph_left = x0 + (info.bearing_x * scale_x).round();
-                            let baseline_in_cell =
-                                (baseline_offset * scale_y).round();
+                            let baseline_in_cell = (baseline_offset * scale_y).round();
                             let glyph_top = y0 + baseline_in_cell - info.bearing_y;
 
                             let render_w = info.width as f32 * scale_x;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,7 +34,7 @@ pub use types::{
 // KeyModifier is exported for potential future use (e.g., custom keybinding UI)
 pub use automation::{CoprocessDefConfig, RestartPolicy, TriggerActionConfig, TriggerConfig};
 // Snippets and custom actions
-pub use snippets::{BuiltInVariable, CustomActionConfig, SnippetConfig};
+pub use snippets::{BuiltInVariable, CustomActionConfig, SnippetConfig, SnippetLibrary};
 #[allow(unused_imports)]
 pub use types::KeyModifier;
 #[allow(unused_imports)]

--- a/src/config/snippets.rs
+++ b/src/config/snippets.rs
@@ -102,6 +102,15 @@ impl SnippetConfig {
     }
 }
 
+/// A portable snippet library for import/export.
+///
+/// Wraps a list of snippets for serialization to/from YAML files.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnippetLibrary {
+    /// The snippets in this library
+    pub snippets: Vec<SnippetConfig>,
+}
+
 /// A custom action that can be triggered via keybinding.
 ///
 /// Actions can execute shell commands, insert text, or simulate key sequences.

--- a/src/keybindings/mod.rs
+++ b/src/keybindings/mod.rs
@@ -9,13 +9,14 @@
 //! - Physical key support for language-agnostic bindings
 
 mod matcher;
-mod parser;
+pub mod parser;
 
 pub use matcher::KeybindingMatcher;
 pub use parser::KeyCombo;
 // ParseError exported for consumers who might want to handle parsing errors
 #[allow(unused_imports)]
 pub use parser::ParseError;
+pub use parser::{key_combo_to_bytes, parse_key_sequence};
 
 use crate::config::{KeyBinding, ModifierRemapping};
 use std::collections::HashMap;

--- a/src/settings_ui/mod.rs
+++ b/src/settings_ui/mod.rs
@@ -270,6 +270,8 @@ pub struct SettingsUI {
     pub(crate) temp_snippet_keybinding_enabled: bool,
     /// Temporary snippet auto_execute for edit form
     pub(crate) temp_snippet_auto_execute: bool,
+    /// Temporary snippet custom variables for edit form (ordered pairs for stable UI)
+    pub(crate) temp_snippet_variables: Vec<(String, String)>,
     /// Whether the add-new-snippet form is active
     pub(crate) adding_new_snippet: bool,
     /// Whether currently recording a keybinding for a snippet
@@ -427,6 +429,7 @@ impl SettingsUI {
             temp_snippet_description: String::new(),
             temp_snippet_keybinding_enabled: true,
             temp_snippet_auto_execute: false,
+            temp_snippet_variables: Vec::new(),
             adding_new_snippet: false,
             editing_action_index: None,
             temp_action_type: 0,

--- a/src/url_detection.rs
+++ b/src/url_detection.rs
@@ -638,7 +638,11 @@ mod tests {
     fn test_absolute_path_with_multiple_components() {
         let text = "/Users/probello/.claude";
         let paths = detect_file_paths_in_line(text, 0);
-        assert_eq!(paths.len(), 1, "Should match absolute path at start of string");
+        assert_eq!(
+            paths.len(),
+            1,
+            "Should match absolute path at start of string"
+        );
         assert_eq!(paths[0].url, "/Users/probello/.claude");
         assert_eq!(paths[0].start_col, 0);
     }
@@ -647,7 +651,11 @@ mod tests {
     fn test_absolute_path_after_whitespace() {
         let text = "ls /Users/probello/.claude";
         let paths = detect_file_paths_in_line(text, 0);
-        assert_eq!(paths.len(), 1, "Should match absolute path after whitespace");
+        assert_eq!(
+            paths.len(),
+            1,
+            "Should match absolute path after whitespace"
+        );
         assert_eq!(paths[0].url, "/Users/probello/.claude");
         assert_eq!(paths[0].start_col, 3);
     }
@@ -657,7 +665,11 @@ mod tests {
         // Single-component paths like /etc are too likely to be false positives
         let text = "/etc";
         let paths = detect_file_paths_in_line(text, 0);
-        assert_eq!(paths.len(), 0, "Should not match single-component absolute paths");
+        assert_eq!(
+            paths.len(),
+            0,
+            "Should not match single-component absolute paths"
+        );
     }
 
     #[test]
@@ -665,7 +677,11 @@ mod tests {
         // Absolute path branch should NOT match /bar/baz inside ./foo/bar/baz
         let text = "./foo/bar/baz";
         let paths = detect_file_paths_in_line(text, 0);
-        assert_eq!(paths.len(), 1, "Should only match the relative path, not internal absolute");
+        assert_eq!(
+            paths.len(),
+            1,
+            "Should only match the relative path, not internal absolute"
+        );
         assert_eq!(paths[0].url, "./foo/bar/baz");
     }
 


### PR DESCRIPTION
## Summary

- **Custom Variables UI**: Collapsible editor in snippet edit form for managing per-snippet variables (name/value grid with add/delete)
- **Key Sequence Simulation**: `KeySequence` actions now parse and send terminal byte sequences (Ctrl combos, arrow keys, F-keys, Enter, etc.)
- **Snippet Import/Export**: Export all snippets to YAML file and import from YAML with duplicate detection and keybinding conflict resolution

Closes #101

## Test plan
- [x] `make checkall` passes (fmt, lint, test, build)
- [x] 50 integration tests + 17 parser unit tests all pass
- [x] Manual: Settings > Snippets > edit snippet > add custom variables > save > reopen > variables persisted
- [x] Manual: Create KeySequence action with "Ctrl+C" > trigger > verify interrupt sent
- [x] Manual: Export snippets > delete > import > verify restored