### PR TITLE
feat(arrangements): save and restore window layouts (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Window Arrangements** (#103): Save and restore window layouts (iTerm2 parity)
+  - **Save**: Capture current window positions, sizes, tab CWDs, and active tab indices as named arrangements
+  - **Restore**: Recreate saved layouts, replacing all current windows
+  - **Monitor-aware**: Positions stored relative to monitor origin for portability across display configurations
+  - **Monitor matching**: Restores windows to correct monitors by name, then index fallback, then primary monitor
+  - **Position clamping**: Ensures restored windows are visible even if monitor layout has changed
+  - **Auto-restore on startup**: Configure an arrangement to restore automatically when the app launches
+  - **Settings UI**: New "Arrangements" tab (📐) with save, restore, rename, delete, and reorder controls
+  - **Menu integration**: "Save Window Arrangement..." item in View menu
+  - **Keybinding support**: `save_arrangement` and `restore_arrangement:<name>` keybinding actions
+  - **YAML persistence**: Arrangements stored in `~/.config/par-term/arrangements.yaml`
+
+### Fixed
+
+- **Update notification clipped on some systems**: Shortened the new version notification body text and added a timeout to prevent content being cut off in small system notification windows
+
 ---
 
 ## [0.13.0] - 2026-02-10

--- a/src/app/input_events.rs
+++ b/src/app/input_events.rs
@@ -1494,12 +1494,35 @@ impl WindowState {
                 );
                 true
             }
+            "save_arrangement" => {
+                // Open settings to Arrangements tab
+                self.open_settings_window_requested = true;
+                if let Some(window) = &self.window {
+                    window.request_redraw();
+                }
+                log::info!("Save arrangement requested via keybinding");
+                true
+            }
             _ => {
                 // Check for snippet or action keybindings
                 if let Some(snippet_id) = action.strip_prefix("snippet:") {
                     self.execute_snippet(snippet_id)
                 } else if let Some(action_id) = action.strip_prefix("action:") {
                     self.execute_custom_action(action_id)
+                } else if let Some(arrangement_name) =
+                    action.strip_prefix("restore_arrangement:")
+                {
+                    // Restore arrangement by name - handled by WindowManager
+                    self.pending_arrangement_restore =
+                        Some(arrangement_name.to_string());
+                    if let Some(window) = &self.window {
+                        window.request_redraw();
+                    }
+                    log::info!(
+                        "Arrangement restore requested via keybinding: {}",
+                        arrangement_name
+                    );
+                    true
                 } else {
                     log::warn!("Unknown keybinding action: {}", action);
                     false

--- a/src/app/window_state.rs
+++ b/src/app/window_state.rs
@@ -170,6 +170,9 @@ pub struct WindowState {
     /// This is set by keyboard handlers and consumed by the window manager
     pub(crate) open_settings_window_requested: bool,
 
+    /// Pending arrangement restore request (name of arrangement to restore)
+    pub(crate) pending_arrangement_restore: Option<String>,
+
     // Profile management
     /// Profile manager for storing and managing terminal profiles
     pub(crate) profile_manager: ProfileManager,
@@ -314,6 +317,7 @@ impl WindowState {
             cursor_shader_reload_result: None,
 
             open_settings_window_requested: false,
+            pending_arrangement_restore: None,
 
             profile_manager,
             profile_drawer_ui: ProfileDrawerUI::new(),

--- a/src/arrangements/capture.rs
+++ b/src/arrangements/capture.rs
@@ -1,0 +1,105 @@
+//! Capture current window arrangement from live windows
+
+use super::{MonitorInfo, TabSnapshot, WindowArrangement, WindowSnapshot};
+use crate::app::window_state::WindowState;
+use std::collections::HashMap;
+use uuid::Uuid;
+use winit::event_loop::ActiveEventLoop;
+use winit::window::WindowId;
+
+/// Build a MonitorInfo from a winit MonitorHandle
+fn monitor_info_from_handle(handle: &winit::monitor::MonitorHandle, index: usize) -> MonitorInfo {
+    let pos = handle.position();
+    let size = handle.size();
+    MonitorInfo {
+        name: handle.name(),
+        index,
+        position: (pos.x, pos.y),
+        size: (size.width, size.height),
+    }
+}
+
+/// Capture the current window arrangement
+///
+/// Enumerates all monitors and windows, capturing their positions (relative to
+/// their monitor), sizes, and tab CWDs.
+pub fn capture_arrangement(
+    name: String,
+    windows: &HashMap<WindowId, WindowState>,
+    event_loop: &ActiveEventLoop,
+) -> WindowArrangement {
+    // Enumerate all monitors
+    let monitors: Vec<_> = event_loop.available_monitors().collect();
+    let monitor_layout: Vec<MonitorInfo> = monitors
+        .iter()
+        .enumerate()
+        .map(|(i, m)| monitor_info_from_handle(m, i))
+        .collect();
+
+    // Capture each window
+    let mut window_snapshots = Vec::new();
+    for window_state in windows.values() {
+        let Some(window) = &window_state.window else {
+            continue;
+        };
+
+        // Determine which monitor this window is on
+        let current_monitor = window.current_monitor();
+        let monitor_info = if let Some(ref mon) = current_monitor {
+            // Find the index of this monitor in our list
+            let index = monitors
+                .iter()
+                .position(|m| m.name() == mon.name() && m.position() == mon.position())
+                .unwrap_or(0);
+            monitor_info_from_handle(mon, index)
+        } else {
+            // Fallback to primary/first monitor
+            monitor_layout.first().cloned().unwrap_or(MonitorInfo {
+                name: None,
+                index: 0,
+                position: (0, 0),
+                size: (1920, 1080),
+            })
+        };
+
+        // Compute position relative to monitor origin
+        let window_pos = window.outer_position().unwrap_or_default();
+        let position_relative = (
+            window_pos.x - monitor_info.position.0,
+            window_pos.y - monitor_info.position.1,
+        );
+
+        let outer_size = window.outer_size();
+        let size = (outer_size.width, outer_size.height);
+
+        // Capture tabs
+        let tabs: Vec<TabSnapshot> = window_state
+            .tab_manager
+            .tabs()
+            .iter()
+            .map(|tab| TabSnapshot {
+                cwd: tab.get_cwd(),
+                title: tab.title.clone(),
+            })
+            .collect();
+
+        let active_tab_index = window_state.tab_manager.active_tab_index().unwrap_or(0);
+
+        window_snapshots.push(WindowSnapshot {
+            monitor: monitor_info,
+            position_relative,
+            size,
+            tabs,
+            active_tab_index,
+        });
+    }
+
+    WindowArrangement {
+        id: Uuid::new_v4(),
+        name,
+        monitor_layout,
+        windows: window_snapshots,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        order: 0,
+    }
+}

--- a/src/arrangements/mod.rs
+++ b/src/arrangements/mod.rs
@@ -1,0 +1,348 @@
+//! Window arrangement types and manager for saving/restoring window layouts
+//!
+//! Arrangements capture the positions, sizes, and tab CWDs of all windows
+//! so they can be restored later. Monitor-aware to handle external monitor
+//! disconnect/reconnect scenarios.
+
+pub mod capture;
+pub mod restore;
+pub mod storage;
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Unique identifier for an arrangement
+pub type ArrangementId = Uuid;
+
+/// Information about a monitor at capture time
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitorInfo {
+    /// Monitor name (primary matching key, e.g. "DELL U2720Q")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Monitor index (fallback matching)
+    #[serde(default)]
+    pub index: usize,
+
+    /// Monitor position in virtual screen coordinates
+    #[serde(default)]
+    pub position: (i32, i32),
+
+    /// Monitor size in physical pixels
+    #[serde(default)]
+    pub size: (u32, u32),
+}
+
+/// Snapshot of a single tab's state
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabSnapshot {
+    /// Working directory (from Tab::get_cwd())
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+
+    /// Tab title
+    #[serde(default)]
+    pub title: String,
+}
+
+/// Snapshot of a single window's state
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowSnapshot {
+    /// Monitor this window was on
+    pub monitor: MonitorInfo,
+
+    /// Position relative to monitor origin (portable across setups)
+    pub position_relative: (i32, i32),
+
+    /// Outer window size in physical pixels
+    pub size: (u32, u32),
+
+    /// Tabs in this window
+    pub tabs: Vec<TabSnapshot>,
+
+    /// Index of the active tab
+    #[serde(default)]
+    pub active_tab_index: usize,
+}
+
+/// A saved window arrangement
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowArrangement {
+    /// Unique identifier
+    pub id: ArrangementId,
+
+    /// Display name for the arrangement
+    pub name: String,
+
+    /// All monitors present at capture time
+    pub monitor_layout: Vec<MonitorInfo>,
+
+    /// All windows in this arrangement
+    pub windows: Vec<WindowSnapshot>,
+
+    /// ISO 8601 timestamp when the arrangement was created
+    #[serde(default)]
+    pub created_at: String,
+
+    /// Display order
+    #[serde(default)]
+    pub order: usize,
+}
+
+/// Manages a collection of saved window arrangements
+#[derive(Debug, Clone, Default)]
+pub struct ArrangementManager {
+    /// All arrangements indexed by ID
+    arrangements: HashMap<ArrangementId, WindowArrangement>,
+
+    /// Ordered list of arrangement IDs for display
+    order: Vec<ArrangementId>,
+}
+
+impl ArrangementManager {
+    /// Create a new empty arrangement manager
+    pub fn new() -> Self {
+        Self {
+            arrangements: HashMap::new(),
+            order: Vec::new(),
+        }
+    }
+
+    /// Create a manager from a list of arrangements
+    pub fn from_arrangements(arrangements: Vec<WindowArrangement>) -> Self {
+        let mut manager = Self::new();
+        for arrangement in arrangements {
+            manager.add(arrangement);
+        }
+        manager.sort_by_order();
+        manager
+    }
+
+    /// Add an arrangement to the manager
+    pub fn add(&mut self, arrangement: WindowArrangement) {
+        let id = arrangement.id;
+        if !self.order.contains(&id) {
+            self.order.push(id);
+        }
+        self.arrangements.insert(id, arrangement);
+    }
+
+    /// Get an arrangement by ID
+    pub fn get(&self, id: &ArrangementId) -> Option<&WindowArrangement> {
+        self.arrangements.get(id)
+    }
+
+    /// Get a mutable reference to an arrangement by ID
+    pub fn get_mut(&mut self, id: &ArrangementId) -> Option<&mut WindowArrangement> {
+        self.arrangements.get_mut(id)
+    }
+
+    /// Update an arrangement (replaces if exists)
+    pub fn update(&mut self, arrangement: WindowArrangement) {
+        let id = arrangement.id;
+        if self.arrangements.contains_key(&id) {
+            self.arrangements.insert(id, arrangement);
+        }
+    }
+
+    /// Remove an arrangement by ID
+    pub fn remove(&mut self, id: &ArrangementId) -> Option<WindowArrangement> {
+        self.order.retain(|aid| aid != id);
+        self.arrangements.remove(id)
+    }
+
+    /// Get all arrangements in display order
+    pub fn arrangements_ordered(&self) -> Vec<&WindowArrangement> {
+        self.order
+            .iter()
+            .filter_map(|id| self.arrangements.get(id))
+            .collect()
+    }
+
+    /// Get all arrangements as a vector (for serialization)
+    pub fn to_vec(&self) -> Vec<WindowArrangement> {
+        self.arrangements_ordered().into_iter().cloned().collect()
+    }
+
+    /// Get the number of arrangements
+    pub fn len(&self) -> usize {
+        self.arrangements.len()
+    }
+
+    /// Check if there are no arrangements
+    pub fn is_empty(&self) -> bool {
+        self.arrangements.is_empty()
+    }
+
+    /// Find an arrangement by name (case-insensitive)
+    pub fn find_by_name(&self, name: &str) -> Option<&WindowArrangement> {
+        let lower = name.to_lowercase();
+        self.arrangements
+            .values()
+            .find(|a| a.name.to_lowercase() == lower)
+    }
+
+    /// Move an arrangement earlier in the order (towards index 0)
+    pub fn move_up(&mut self, id: &ArrangementId) {
+        if let Some(pos) = self.order.iter().position(|aid| aid == id)
+            && pos > 0
+        {
+            self.order.swap(pos, pos - 1);
+            self.update_orders();
+        }
+    }
+
+    /// Move an arrangement later in the order (towards the end)
+    pub fn move_down(&mut self, id: &ArrangementId) {
+        if let Some(pos) = self.order.iter().position(|aid| aid == id)
+            && pos < self.order.len() - 1
+        {
+            self.order.swap(pos, pos + 1);
+            self.update_orders();
+        }
+    }
+
+    /// Sort arrangements by their order field
+    fn sort_by_order(&mut self) {
+        self.order.sort_by_key(|id| {
+            self.arrangements
+                .get(id)
+                .map(|a| a.order)
+                .unwrap_or(usize::MAX)
+        });
+    }
+
+    /// Update the order field of all arrangements to match their position
+    fn update_orders(&mut self) {
+        for (i, id) in self.order.iter().enumerate() {
+            if let Some(arrangement) = self.arrangements.get_mut(id) {
+                arrangement.order = i;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_arrangement(name: &str, order: usize) -> WindowArrangement {
+        WindowArrangement {
+            id: Uuid::new_v4(),
+            name: name.to_string(),
+            monitor_layout: Vec::new(),
+            windows: Vec::new(),
+            created_at: String::new(),
+            order,
+        }
+    }
+
+    #[test]
+    fn test_manager_basic_operations() {
+        let mut manager = ArrangementManager::new();
+        assert!(manager.is_empty());
+
+        let arr = make_arrangement("Test", 0);
+        let id = arr.id;
+        manager.add(arr);
+
+        assert_eq!(manager.len(), 1);
+        assert!(manager.get(&id).is_some());
+        assert_eq!(manager.get(&id).unwrap().name, "Test");
+
+        let removed = manager.remove(&id);
+        assert!(removed.is_some());
+        assert!(manager.is_empty());
+    }
+
+    #[test]
+    fn test_manager_ordering() {
+        let mut manager = ArrangementManager::new();
+
+        let a1 = make_arrangement("First", 0);
+        let a2 = make_arrangement("Second", 1);
+        let a3 = make_arrangement("Third", 2);
+
+        let id1 = a1.id;
+        let id2 = a2.id;
+        let id3 = a3.id;
+
+        manager.add(a1);
+        manager.add(a2);
+        manager.add(a3);
+
+        let ordered = manager.arrangements_ordered();
+        assert_eq!(ordered.len(), 3);
+        assert_eq!(ordered[0].id, id1);
+        assert_eq!(ordered[1].id, id2);
+        assert_eq!(ordered[2].id, id3);
+
+        // Move second to first position
+        manager.move_up(&id2);
+        let ordered = manager.arrangements_ordered();
+        assert_eq!(ordered[0].id, id2);
+        assert_eq!(ordered[1].id, id1);
+
+        // Move second (now first) down
+        manager.move_down(&id2);
+        let ordered = manager.arrangements_ordered();
+        assert_eq!(ordered[0].id, id1);
+        assert_eq!(ordered[1].id, id2);
+    }
+
+    #[test]
+    fn test_find_by_name() {
+        let mut manager = ArrangementManager::new();
+        manager.add(make_arrangement("Work Setup", 0));
+        manager.add(make_arrangement("Home Setup", 1));
+
+        assert!(manager.find_by_name("work setup").is_some());
+        assert!(manager.find_by_name("HOME SETUP").is_some());
+        assert!(manager.find_by_name("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_serialization() {
+        let arr = WindowArrangement {
+            id: Uuid::new_v4(),
+            name: "Test".to_string(),
+            monitor_layout: vec![MonitorInfo {
+                name: Some("DELL U2720Q".to_string()),
+                index: 0,
+                position: (0, 0),
+                size: (2560, 1440),
+            }],
+            windows: vec![WindowSnapshot {
+                monitor: MonitorInfo {
+                    name: Some("DELL U2720Q".to_string()),
+                    index: 0,
+                    position: (0, 0),
+                    size: (2560, 1440),
+                },
+                position_relative: (100, 200),
+                size: (800, 600),
+                tabs: vec![TabSnapshot {
+                    cwd: Some("/home/user".to_string()),
+                    title: "bash".to_string(),
+                }],
+                active_tab_index: 0,
+            }],
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            order: 0,
+        };
+
+        let yaml = serde_yaml::to_string(&arr).unwrap();
+        let deserialized: WindowArrangement = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(deserialized.id, arr.id);
+        assert_eq!(deserialized.name, arr.name);
+        assert_eq!(deserialized.windows.len(), 1);
+        assert_eq!(deserialized.windows[0].tabs.len(), 1);
+        assert_eq!(
+            deserialized.windows[0].tabs[0].cwd,
+            Some("/home/user".to_string())
+        );
+    }
+}

--- a/src/arrangements/restore.rs
+++ b/src/arrangements/restore.rs
@@ -1,0 +1,196 @@
+//! Monitor-aware restore logic for window arrangements
+
+use super::{MonitorInfo, WindowArrangement};
+use std::collections::HashMap;
+use winit::monitor::MonitorHandle;
+
+/// Build a mapping from saved monitor indices to available monitor indices.
+///
+/// Matching priority:
+/// 1. Match by monitor name (e.g., "DELL U2720Q")
+/// 2. Fall back to matching by index
+/// 3. Fall back to primary/first monitor (index 0)
+pub fn build_monitor_mapping(
+    saved_monitors: &[MonitorInfo],
+    available: &[MonitorHandle],
+) -> HashMap<usize, usize> {
+    let mut mapping = HashMap::new();
+
+    for saved in saved_monitors {
+        let matched_index = if let Some(ref saved_name) = saved.name {
+            // Try matching by name first
+            available
+                .iter()
+                .position(|m| m.name().as_deref() == Some(saved_name.as_str()))
+        } else {
+            None
+        };
+
+        let matched_index = matched_index.unwrap_or({
+            // Fall back to index if available
+            if saved.index < available.len() {
+                saved.index
+            } else {
+                // Fall back to primary (index 0)
+                0
+            }
+        });
+
+        mapping.insert(saved.index, matched_index);
+    }
+
+    mapping
+}
+
+/// Clamp a window position and size to ensure it's visible on the target monitor.
+///
+/// Returns (clamped_x, clamped_y, clamped_width, clamped_height).
+pub fn clamp_to_monitor(
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    monitor_pos: (i32, i32),
+    monitor_size: (u32, u32),
+) -> (i32, i32, u32, u32) {
+    // Ensure window isn't larger than the monitor
+    let clamped_width = width.min(monitor_size.0);
+    let clamped_height = height.min(monitor_size.1);
+
+    // Ensure the window is at least partially visible on the monitor
+    // Allow a minimum of 100px visible on each axis
+    let min_visible = 100i32;
+    let clamped_x = x
+        .max(monitor_pos.0 - clamped_width as i32 + min_visible)
+        .min(monitor_pos.0 + monitor_size.0 as i32 - min_visible);
+    let clamped_y = y
+        .max(monitor_pos.1 - clamped_height as i32 + min_visible)
+        .min(monitor_pos.1 + monitor_size.1 as i32 - min_visible);
+
+    (clamped_x, clamped_y, clamped_width, clamped_height)
+}
+
+/// Compute the absolute position and size for a window snapshot,
+/// given the monitor mapping and available monitors.
+///
+/// Returns (absolute_x, absolute_y, width, height) or None if no monitors available.
+pub fn compute_restore_position(
+    snapshot: &super::WindowSnapshot,
+    monitor_mapping: &HashMap<usize, usize>,
+    available: &[MonitorHandle],
+) -> Option<(i32, i32, u32, u32)> {
+    if available.is_empty() {
+        return None;
+    }
+
+    // Find the target monitor
+    let target_index = monitor_mapping
+        .get(&snapshot.monitor.index)
+        .copied()
+        .unwrap_or(0);
+    let target_monitor = available.get(target_index).or(available.first())?;
+
+    let monitor_pos = target_monitor.position();
+    let monitor_size = target_monitor.size();
+
+    // Convert relative position to absolute
+    let abs_x = monitor_pos.x + snapshot.position_relative.0;
+    let abs_y = monitor_pos.y + snapshot.position_relative.1;
+
+    // Clamp to ensure visibility
+    let (x, y, w, h) = clamp_to_monitor(
+        abs_x,
+        abs_y,
+        snapshot.size.0,
+        snapshot.size.1,
+        (monitor_pos.x, monitor_pos.y),
+        (monitor_size.width, monitor_size.height),
+    );
+
+    Some((x, y, w, h))
+}
+
+/// Get the list of tab CWDs from an arrangement for creating tabs
+pub fn tab_cwds(arrangement: &WindowArrangement, window_index: usize) -> Vec<Option<String>> {
+    arrangement
+        .windows
+        .get(window_index)
+        .map(|ws| ws.tabs.iter().map(|t| t.cwd.clone()).collect())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clamp_to_monitor_within_bounds() {
+        let (x, y, w, h) = clamp_to_monitor(100, 100, 800, 600, (0, 0), (1920, 1080));
+        assert_eq!((x, y, w, h), (100, 100, 800, 600));
+    }
+
+    #[test]
+    fn test_clamp_to_monitor_too_large() {
+        let (_, _, w, h) = clamp_to_monitor(0, 0, 3000, 2000, (0, 0), (1920, 1080));
+        assert_eq!(w, 1920);
+        assert_eq!(h, 1080);
+    }
+
+    #[test]
+    fn test_clamp_to_monitor_offscreen_right() {
+        let (x, _, _, _) = clamp_to_monitor(2000, 0, 800, 600, (0, 0), (1920, 1080));
+        // Window should be clamped so at least 100px visible
+        assert!(x <= 1920 - 100);
+    }
+
+    #[test]
+    fn test_clamp_to_monitor_offscreen_left() {
+        let (x, _, _, _) = clamp_to_monitor(-1000, 0, 800, 600, (0, 0), (1920, 1080));
+        // Window should be clamped so at least 100px visible
+        assert!(x >= -800 + 100);
+    }
+
+    #[test]
+    fn test_tab_cwds() {
+        use super::super::{MonitorInfo, TabSnapshot, WindowArrangement, WindowSnapshot};
+        use uuid::Uuid;
+
+        let arrangement = WindowArrangement {
+            id: Uuid::new_v4(),
+            name: "Test".to_string(),
+            monitor_layout: Vec::new(),
+            windows: vec![WindowSnapshot {
+                monitor: MonitorInfo {
+                    name: None,
+                    index: 0,
+                    position: (0, 0),
+                    size: (1920, 1080),
+                },
+                position_relative: (0, 0),
+                size: (800, 600),
+                tabs: vec![
+                    TabSnapshot {
+                        cwd: Some("/home/user".to_string()),
+                        title: "tab1".to_string(),
+                    },
+                    TabSnapshot {
+                        cwd: None,
+                        title: "tab2".to_string(),
+                    },
+                ],
+                active_tab_index: 0,
+            }],
+            created_at: String::new(),
+            order: 0,
+        };
+
+        let cwds = tab_cwds(&arrangement, 0);
+        assert_eq!(cwds.len(), 2);
+        assert_eq!(cwds[0], Some("/home/user".to_string()));
+        assert_eq!(cwds[1], None);
+
+        // Out of bounds window index
+        let cwds = tab_cwds(&arrangement, 5);
+        assert!(cwds.is_empty());
+    }
+}

--- a/src/arrangements/storage.rs
+++ b/src/arrangements/storage.rs
@@ -1,0 +1,195 @@
+//! Storage utilities for arrangement persistence
+//!
+//! Arrangements are stored in `~/.config/par-term/arrangements.yaml`
+
+use super::{ArrangementManager, WindowArrangement};
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+/// Get the default arrangements file path
+pub fn arrangements_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("par-term")
+        .join("arrangements.yaml")
+}
+
+/// Load arrangements from the default location
+pub fn load_arrangements() -> Result<ArrangementManager> {
+    load_arrangements_from(arrangements_path())
+}
+
+/// Load arrangements from a specific file
+pub fn load_arrangements_from(path: PathBuf) -> Result<ArrangementManager> {
+    crate::debug_info!("ARRANGEMENT", "Loading arrangements from {:?}", path);
+    if !path.exists() {
+        crate::debug_info!(
+            "ARRANGEMENT",
+            "No arrangements file found at {:?}, starting with empty arrangements",
+            path
+        );
+        return Ok(ArrangementManager::new());
+    }
+
+    let contents = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read arrangements from {:?}", path))?;
+
+    crate::debug_info!(
+        "ARRANGEMENT",
+        "Read {} bytes from arrangements file",
+        contents.len()
+    );
+
+    if contents.trim().is_empty() {
+        crate::debug_info!(
+            "ARRANGEMENT",
+            "Arrangements file is empty, starting with empty arrangements"
+        );
+        return Ok(ArrangementManager::new());
+    }
+
+    let arrangements: Vec<WindowArrangement> = serde_yaml::from_str(&contents)
+        .with_context(|| format!("Failed to parse arrangements from {:?}", path))?;
+
+    crate::debug_info!(
+        "ARRANGEMENT",
+        "Parsed {} arrangements from {:?}",
+        arrangements.len(),
+        path
+    );
+    for a in &arrangements {
+        crate::debug_info!(
+            "ARRANGEMENT",
+            "  - {}: {} ({} windows)",
+            a.id,
+            a.name,
+            a.windows.len()
+        );
+    }
+    Ok(ArrangementManager::from_arrangements(arrangements))
+}
+
+/// Save arrangements to the default location
+pub fn save_arrangements(manager: &ArrangementManager) -> Result<()> {
+    save_arrangements_to(manager, arrangements_path())
+}
+
+/// Save arrangements to a specific file
+pub fn save_arrangements_to(manager: &ArrangementManager, path: PathBuf) -> Result<()> {
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create config directory {:?}", parent))?;
+    }
+
+    let arrangements = manager.to_vec();
+    let contents =
+        serde_yaml::to_string(&arrangements).context("Failed to serialize arrangements")?;
+
+    std::fs::write(&path, contents)
+        .with_context(|| format!("Failed to write arrangements to {:?}", path))?;
+
+    log::info!("Saved {} arrangements to {:?}", arrangements.len(), path);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arrangements::{MonitorInfo, TabSnapshot, WindowArrangement, WindowSnapshot};
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_load_nonexistent_file() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("nonexistent.yaml");
+
+        let manager = load_arrangements_from(path).unwrap();
+        assert!(manager.is_empty());
+    }
+
+    #[test]
+    fn test_load_empty_file() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("empty.yaml");
+        std::fs::write(&path, "").unwrap();
+
+        let manager = load_arrangements_from(path).unwrap();
+        assert!(manager.is_empty());
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("arrangements.yaml");
+
+        let mut manager = ArrangementManager::new();
+        manager.add(WindowArrangement {
+            id: Uuid::new_v4(),
+            name: "Work Setup".to_string(),
+            monitor_layout: vec![MonitorInfo {
+                name: Some("Main".to_string()),
+                index: 0,
+                position: (0, 0),
+                size: (1920, 1080),
+            }],
+            windows: vec![WindowSnapshot {
+                monitor: MonitorInfo {
+                    name: Some("Main".to_string()),
+                    index: 0,
+                    position: (0, 0),
+                    size: (1920, 1080),
+                },
+                position_relative: (100, 100),
+                size: (800, 600),
+                tabs: vec![TabSnapshot {
+                    cwd: Some("/home/user/work".to_string()),
+                    title: "work".to_string(),
+                }],
+                active_tab_index: 0,
+            }],
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            order: 0,
+        });
+
+        save_arrangements_to(&manager, path.clone()).unwrap();
+
+        let loaded = load_arrangements_from(path).unwrap();
+        assert_eq!(loaded.len(), 1);
+
+        let arrangements = loaded.arrangements_ordered();
+        assert_eq!(arrangements[0].name, "Work Setup");
+        assert_eq!(arrangements[0].windows.len(), 1);
+        assert_eq!(arrangements[0].windows[0].tabs.len(), 1);
+        assert_eq!(
+            arrangements[0].windows[0].tabs[0].cwd,
+            Some("/home/user/work".to_string())
+        );
+    }
+
+    #[test]
+    fn test_save_creates_parent_directory() {
+        let temp = tempdir().unwrap();
+        let path = temp
+            .path()
+            .join("nested")
+            .join("dir")
+            .join("arrangements.yaml");
+
+        let manager = ArrangementManager::new();
+        save_arrangements_to(&manager, path.clone()).unwrap();
+
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_load_corrupt_file_returns_error() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("corrupt.yaml");
+        std::fs::write(&path, "not: valid: yaml: [[[").unwrap();
+
+        let result = load_arrangements_from(path);
+        assert!(result.is_err());
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1312,6 +1312,13 @@ pub struct Config {
     pub last_notified_version: Option<String>,
 
     // ========================================================================
+    // Window Arrangements
+    // ========================================================================
+    /// Name of arrangement to auto-restore on startup (None = disabled)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_restore_arrangement: Option<String>,
+
+    // ========================================================================
     // Search Settings
     // ========================================================================
     /// Highlight color for search matches [R, G, B, A] (0-255)
@@ -1711,6 +1718,7 @@ impl Default for Config {
             last_update_check: None,
             skipped_version: None,
             last_notified_version: None,
+            auto_restore_arrangement: None,
             search_highlight_color: defaults::search_highlight_color(),
             search_current_highlight_color: defaults::search_current_highlight_color(),
             search_case_sensitive: defaults::bool_false(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod debug;
 
 pub mod app;
+pub mod arrangements;
 pub mod audio_bell;
 pub mod badge;
 pub mod cell_renderer;

--- a/src/menu/actions.rs
+++ b/src/menu/actions.rs
@@ -87,6 +87,10 @@ pub enum MenuAction {
     /// Show about dialog
     About,
 
+    // Window Arrangements
+    /// Save the current window layout as an arrangement
+    SaveArrangement,
+
     // Keybinding actions (triggered by user-defined keybindings or menu)
     /// Toggle background/custom shader on/off
     #[allow(dead_code)]

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -325,6 +325,20 @@ impl MenuManager {
         action_map.insert(settings.id().clone(), MenuAction::OpenSettings);
         view_menu.append(&settings)?;
 
+        view_menu.append(&PredefinedMenuItem::separator())?;
+
+        let save_arrangement = MenuItem::with_id(
+            "save_arrangement",
+            "Save Window Arrangement...",
+            true,
+            None,
+        );
+        action_map.insert(
+            save_arrangement.id().clone(),
+            MenuAction::SaveArrangement,
+        );
+        view_menu.append(&save_arrangement)?;
+
         menu.append(&view_menu)?;
 
         // Window menu (primarily for macOS)

--- a/src/settings_ui/arrangements_tab.rs
+++ b/src/settings_ui/arrangements_tab.rs
@@ -1,0 +1,359 @@
+//! Arrangements settings tab.
+//!
+//! Contains:
+//! - List of saved arrangements with restore/rename/delete/reorder controls
+//! - Save current layout button
+//! - Auto-restore on startup setting
+
+use super::SettingsUI;
+use super::section::collapsing_section;
+use crate::arrangements::ArrangementManager;
+use crate::settings_window::SettingsWindowAction;
+
+/// Show the arrangements tab content.
+pub fn show(ui: &mut egui::Ui, settings: &mut SettingsUI, changes_this_frame: &mut bool) {
+    let query = settings.search_query.trim().to_lowercase();
+
+    if section_matches(
+        &query,
+        "Save Current Layout",
+        &["save", "capture", "current"],
+    ) {
+        show_save_section(ui, settings);
+    }
+
+    if section_matches(
+        &query,
+        "Saved Arrangements",
+        &[
+            "arrangement",
+            "restore",
+            "rename",
+            "delete",
+            "layout",
+            "workspace",
+        ],
+    ) {
+        show_arrangements_list(ui, settings);
+    }
+
+    if section_matches(
+        &query,
+        "Auto-Restore",
+        &["auto", "startup", "restore", "default"],
+    ) {
+        show_auto_restore_section(ui, settings, changes_this_frame);
+    }
+}
+
+fn section_matches(query: &str, title: &str, keywords: &[&str]) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    if title.to_lowercase().contains(query) {
+        return true;
+    }
+    keywords.iter().any(|k| k.to_lowercase().contains(query))
+}
+
+// ============================================================================
+// Save Current Layout Section
+// ============================================================================
+
+fn show_save_section(ui: &mut egui::Ui, settings: &mut SettingsUI) {
+    collapsing_section(
+        ui,
+        "Save Current Layout",
+        "arrangements_save",
+        true,
+        |ui| {
+            ui.label("Save the current window arrangement (positions, sizes, and tab working directories) for later restoration.");
+            ui.add_space(8.0);
+
+            ui.horizontal(|ui| {
+                ui.label("Name:");
+                ui.text_edit_singleline(&mut settings.arrangement_save_name);
+
+                let name_valid = !settings.arrangement_save_name.trim().is_empty();
+                if ui
+                    .add_enabled(name_valid, egui::Button::new("Save"))
+                    .clicked()
+                {
+                    let name = settings.arrangement_save_name.trim().to_string();
+                    settings.pending_arrangement_actions.push(
+                        SettingsWindowAction::SaveArrangement(name),
+                    );
+                    settings.arrangement_save_name.clear();
+                }
+            });
+        },
+    );
+}
+
+// ============================================================================
+// Saved Arrangements List
+// ============================================================================
+
+fn show_arrangements_list(ui: &mut egui::Ui, settings: &mut SettingsUI) {
+    collapsing_section(
+        ui,
+        "Saved Arrangements",
+        "arrangements_list",
+        true,
+        |ui| {
+            let manager = settings.arrangement_manager.clone();
+            show_arrangements_with_manager(ui, settings, &manager);
+
+            ui.add_space(4.0);
+
+            // Show confirmation dialogs
+            show_confirm_restore_dialog(ui, settings);
+            show_confirm_delete_dialog(ui, settings);
+            show_rename_dialog(ui, settings);
+        },
+    );
+}
+
+/// Render the arrangements list with data from the ArrangementManager.
+///
+/// Called by the settings window with the actual manager data.
+pub fn show_arrangements_with_manager(
+    ui: &mut egui::Ui,
+    settings: &mut SettingsUI,
+    manager: &ArrangementManager,
+) {
+    if manager.is_empty() {
+        ui.label(
+            egui::RichText::new("No saved arrangements yet.")
+                .italics()
+                .color(egui::Color32::from_rgb(150, 150, 150)),
+        );
+        return;
+    }
+
+    let arrangements = manager.arrangements_ordered();
+    for (i, arr) in arrangements.iter().enumerate() {
+        let id = arr.id;
+        let total_tabs: usize = arr.windows.iter().map(|w| w.tabs.len()).sum();
+
+        ui.horizontal(|ui| {
+            // Name and summary
+            ui.label(
+                egui::RichText::new(&arr.name)
+                    .strong()
+                    .color(egui::Color32::from_rgb(220, 220, 220)),
+            );
+            ui.label(
+                egui::RichText::new(format!(
+                    "({} window{}, {} tab{})",
+                    arr.windows.len(),
+                    if arr.windows.len() == 1 { "" } else { "s" },
+                    total_tabs,
+                    if total_tabs == 1 { "" } else { "s" },
+                ))
+                .color(egui::Color32::from_rgb(140, 140, 140)),
+            );
+
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                // Reorder buttons
+                if i < arrangements.len() - 1 && ui.small_button("▼").clicked() {
+                    settings.pending_arrangement_actions.push(
+                        SettingsWindowAction::RenameArrangement(id, "__move_down__".to_string()),
+                    );
+                }
+                if i > 0 && ui.small_button("▲").clicked() {
+                    settings.pending_arrangement_actions.push(
+                        SettingsWindowAction::RenameArrangement(id, "__move_up__".to_string()),
+                    );
+                }
+
+                if ui.small_button("Delete").clicked() {
+                    settings.arrangement_confirm_delete = Some(id);
+                }
+                if ui.small_button("Rename").clicked() {
+                    settings.arrangement_rename_id = Some(id);
+                    settings.arrangement_rename_text = arr.name.clone();
+                }
+                if ui.small_button("Restore").clicked() {
+                    settings.arrangement_confirm_restore = Some(id);
+                }
+            });
+        });
+
+        // Show created date if available
+        if !arr.created_at.is_empty() {
+            ui.label(
+                egui::RichText::new(format!("  Created: {}", format_date(&arr.created_at)))
+                    .small()
+                    .color(egui::Color32::from_rgb(100, 100, 100)),
+            );
+        }
+
+        if i < arrangements.len() - 1 {
+            ui.separator();
+        }
+    }
+}
+
+fn format_date(iso: &str) -> String {
+    // Simple formatting: just show the date portion
+    if let Some(date_part) = iso.split('T').next() {
+        date_part.to_string()
+    } else {
+        iso.to_string()
+    }
+}
+
+// ============================================================================
+// Confirmation Dialogs
+// ============================================================================
+
+fn show_confirm_restore_dialog(ui: &mut egui::Ui, settings: &mut SettingsUI) {
+    if let Some(id) = settings.arrangement_confirm_restore {
+        ui.add_space(8.0);
+        ui.group(|ui| {
+            ui.label(
+                egui::RichText::new("⚠ Restore this arrangement?")
+                    .strong()
+                    .color(egui::Color32::from_rgb(255, 193, 7)),
+            );
+            ui.label("This will close all current windows and restore the saved layout.");
+            ui.horizontal(|ui| {
+                if ui.button("Restore").clicked() {
+                    settings
+                        .pending_arrangement_actions
+                        .push(SettingsWindowAction::RestoreArrangement(id));
+                    settings.arrangement_confirm_restore = None;
+                }
+                if ui.button("Cancel").clicked() {
+                    settings.arrangement_confirm_restore = None;
+                }
+            });
+        });
+    }
+}
+
+fn show_confirm_delete_dialog(ui: &mut egui::Ui, settings: &mut SettingsUI) {
+    if let Some(id) = settings.arrangement_confirm_delete {
+        ui.add_space(8.0);
+        ui.group(|ui| {
+            ui.label(
+                egui::RichText::new("⚠ Delete this arrangement?")
+                    .strong()
+                    .color(egui::Color32::from_rgb(244, 67, 54)),
+            );
+            ui.label("This cannot be undone.");
+            ui.horizontal(|ui| {
+                if ui.button("Delete").clicked() {
+                    settings
+                        .pending_arrangement_actions
+                        .push(SettingsWindowAction::DeleteArrangement(id));
+                    settings.arrangement_confirm_delete = None;
+                }
+                if ui.button("Cancel").clicked() {
+                    settings.arrangement_confirm_delete = None;
+                }
+            });
+        });
+    }
+}
+
+fn show_rename_dialog(ui: &mut egui::Ui, settings: &mut SettingsUI) {
+    if let Some(id) = settings.arrangement_rename_id {
+        ui.add_space(8.0);
+        ui.group(|ui| {
+            ui.label(egui::RichText::new("Rename arrangement").strong());
+            ui.horizontal(|ui| {
+                ui.label("New name:");
+                ui.text_edit_singleline(&mut settings.arrangement_rename_text);
+
+                let valid = !settings.arrangement_rename_text.trim().is_empty();
+                if ui.add_enabled(valid, egui::Button::new("Rename")).clicked() {
+                    let new_name = settings.arrangement_rename_text.trim().to_string();
+                    settings
+                        .pending_arrangement_actions
+                        .push(SettingsWindowAction::RenameArrangement(id, new_name));
+                    settings.arrangement_rename_id = None;
+                    settings.arrangement_rename_text.clear();
+                }
+                if ui.button("Cancel").clicked() {
+                    settings.arrangement_rename_id = None;
+                    settings.arrangement_rename_text.clear();
+                }
+            });
+        });
+    }
+}
+
+// ============================================================================
+// Auto-Restore Section
+// ============================================================================
+
+fn show_auto_restore_section(
+    ui: &mut egui::Ui,
+    settings: &mut SettingsUI,
+    changes_this_frame: &mut bool,
+) {
+    collapsing_section(
+        ui,
+        "Auto-Restore on Startup",
+        "arrangements_auto_restore",
+        true,
+        |ui| {
+            ui.label("Automatically restore a saved arrangement when par-term starts.");
+            ui.add_space(8.0);
+
+            let current = settings
+                .config
+                .auto_restore_arrangement
+                .clone()
+                .unwrap_or_default();
+
+            let display = if current.is_empty() {
+                "None (disabled)"
+            } else {
+                &current
+            };
+
+            // Build list of arrangement names for the dropdown
+            let arrangements = settings.arrangement_manager.arrangements_ordered();
+            let names: Vec<&str> = arrangements.iter().map(|a| a.name.as_str()).collect();
+
+            ui.horizontal(|ui| {
+                ui.label("Auto-restore:");
+                egui::ComboBox::from_id_salt("auto_restore_arrangement")
+                    .selected_text(display)
+                    .show_ui(ui, |ui| {
+                        // "None" option to disable
+                        if ui
+                            .selectable_label(current.is_empty(), "None (disabled)")
+                            .clicked()
+                        {
+                            settings.config.auto_restore_arrangement = None;
+                            settings.has_changes = true;
+                            *changes_this_frame = true;
+                        }
+
+                        // One option per saved arrangement
+                        for name in &names {
+                            let selected = current == *name;
+                            if ui.selectable_label(selected, *name).clicked() {
+                                settings.config.auto_restore_arrangement =
+                                    Some((*name).to_string());
+                                settings.has_changes = true;
+                                *changes_this_frame = true;
+                            }
+                        }
+                    });
+            });
+
+            if names.is_empty() {
+                ui.label(
+                    egui::RichText::new("Save an arrangement first to enable auto-restore.")
+                        .small()
+                        .color(egui::Color32::from_rgb(100, 100, 100)),
+                );
+            }
+        },
+    );
+}

--- a/src/settings_ui/mod.rs
+++ b/src/settings_ui/mod.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 // Reorganized settings tabs (12 consolidated tabs)
 pub mod actions_tab;
 pub mod advanced_tab;
+pub mod arrangements_tab;
 pub mod appearance_tab;
 pub mod automation_tab;
 pub mod badge_tab;
@@ -308,6 +309,22 @@ pub struct SettingsUI {
     // Reset to defaults dialog state
     /// Whether to show the reset to defaults confirmation dialog
     pub(crate) show_reset_defaults_dialog: bool,
+
+    // Arrangements tab state
+    /// Name for saving a new arrangement
+    pub(crate) arrangement_save_name: String,
+/// Arrangement ID pending restore confirmation
+    pub(crate) arrangement_confirm_restore: Option<crate::arrangements::ArrangementId>,
+    /// Arrangement ID pending delete confirmation
+    pub(crate) arrangement_confirm_delete: Option<crate::arrangements::ArrangementId>,
+    /// Arrangement ID being renamed
+    pub(crate) arrangement_rename_id: Option<crate::arrangements::ArrangementId>,
+    /// Text buffer for rename operation
+    pub(crate) arrangement_rename_text: String,
+    /// Pending arrangement actions to send to the main window
+    pub(crate) pending_arrangement_actions: Vec<crate::settings_window::SettingsWindowAction>,
+    /// Cached arrangement manager data (synced from WindowManager)
+    pub(crate) arrangement_manager: crate::arrangements::ArrangementManager,
 }
 
 impl SettingsUI {
@@ -446,6 +463,13 @@ impl SettingsUI {
             recording_action_keybinding: false,
             action_recorded_combo: None,
             show_reset_defaults_dialog: false,
+            arrangement_save_name: String::new(),
+            arrangement_confirm_restore: None,
+            arrangement_confirm_delete: None,
+            arrangement_rename_id: None,
+            arrangement_rename_text: String::new(),
+            pending_arrangement_actions: Vec::new(),
+            arrangement_manager: crate::arrangements::ArrangementManager::new(),
         }
     }
 
@@ -1191,6 +1215,9 @@ impl SettingsUI {
             }
             SettingsTab::Actions => {
                 actions_tab::show(ui, self, changes_this_frame);
+            }
+            SettingsTab::Arrangements => {
+                arrangements_tab::show(ui, self, changes_this_frame);
             }
             SettingsTab::Advanced => {
                 advanced_tab::show(ui, self, changes_this_frame);

--- a/src/settings_ui/sidebar.rs
+++ b/src/settings_ui/sidebar.rs
@@ -22,6 +22,7 @@ pub enum SettingsTab {
     Automation,
     Snippets,
     Actions,
+    Arrangements,
     Advanced,
 }
 
@@ -42,6 +43,7 @@ impl SettingsTab {
             Self::Automation => "Automation",
             Self::Snippets => "Snippets",
             Self::Actions => "Actions",
+            Self::Arrangements => "Arrangements",
             Self::Advanced => "Advanced",
         }
     }
@@ -62,6 +64,7 @@ impl SettingsTab {
             Self::Automation => "⚡",
             Self::Snippets => "📝",
             Self::Actions => "🚀",
+            Self::Arrangements => "📐",
             Self::Advanced => "⚙",
         }
     }
@@ -82,6 +85,7 @@ impl SettingsTab {
             Self::Automation,
             Self::Snippets,
             Self::Actions,
+            Self::Arrangements,
             Self::Advanced,
         ]
     }
@@ -616,6 +620,17 @@ fn tab_search_keywords(tab: SettingsTab) -> &'static [&'static str] {
             "automation",
             "shortcut",
         ],
+        SettingsTab::Arrangements => &[
+            "arrangement",
+            "arrangements",
+            "layout",
+            "workspace",
+            "save",
+            "restore",
+            "monitor",
+            "window layout",
+            "auto-restore",
+        ],
         SettingsTab::Advanced => &[
             // tmux
             "tmux",
@@ -687,6 +702,7 @@ fn tab_contents_summary(tab: SettingsTab) -> &'static str {
         SettingsTab::Automation => "Regex triggers, trigger actions, coprocesses",
         SettingsTab::Snippets => "Text snippets with variable substitution",
         SettingsTab::Actions => "Custom actions (shell, text, keys)",
+        SettingsTab::Arrangements => "Save and restore window layouts",
         SettingsTab::Advanced => "tmux integration, logging, updates, debug logging",
     }
 }

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -38,6 +38,14 @@ pub enum SettingsWindowAction {
     StopCoprocess(usize),
     /// Open the debug log file in the system's default editor/viewer
     OpenLogFile,
+    /// Save the current window layout as an arrangement
+    SaveArrangement(String),
+    /// Restore a saved window arrangement
+    RestoreArrangement(crate::arrangements::ArrangementId),
+    /// Delete a saved window arrangement
+    DeleteArrangement(crate::arrangements::ArrangementId),
+    /// Rename a saved window arrangement
+    RenameArrangement(crate::arrangements::ArrangementId, String),
 }
 
 /// Manages a separate settings window with its own egui context and wgpu renderer
@@ -499,6 +507,12 @@ impl SettingsWindow {
             } else {
                 SettingsWindowAction::StopCoprocess(index)
             };
+        }
+
+        // Check for arrangement actions
+        if let Some(action) = self.settings_ui.pending_arrangement_actions.pop() {
+            self.window.request_redraw();
+            return action;
         }
 
         // Determine action based on settings UI results

--- a/src/tab/manager.rs
+++ b/src/tab/manager.rs
@@ -67,6 +67,31 @@ impl TabManager {
         Ok(id)
     }
 
+    /// Create a new tab with a specific working directory
+    ///
+    /// Used by arrangement restore to create tabs with saved CWDs.
+    pub fn new_tab_with_cwd(
+        &mut self,
+        config: &Config,
+        runtime: Arc<Runtime>,
+        working_dir: Option<String>,
+        grid_size: Option<(usize, usize)>,
+    ) -> Result<TabId> {
+        let id = self.next_tab_id;
+        self.next_tab_id += 1;
+
+        let tab_number = self.tabs.len() + 1;
+        let tab = Tab::new(id, tab_number, config, runtime, working_dir, grid_size)?;
+        self.tabs.push(tab);
+
+        // Always switch to the new tab
+        self.active_tab_id = Some(id);
+
+        log::info!("Created new tab {} with cwd (total: {})", id, self.tabs.len());
+
+        Ok(id)
+    }
+
     /// Create a new tab from a profile configuration
     ///
     /// The profile specifies the working directory, command, and tab name.


### PR DESCRIPTION
## Summary
- Add window arrangements feature: save/restore window positions, sizes, tab CWDs, and active tab indices
- Monitor-aware positioning with name-based matching, index fallback, and position clamping
- New Settings UI "Arrangements" tab with save, restore, rename, delete, reorder, and auto-restore dropdown
- Menu item, keybinding support (`save_arrangement`, `restore_arrangement:<name>`), YAML persistence
- Fix update notification being clipped on some systems

## Test plan
- [ ] Save single-window arrangement → restore → window matches position/size/tabs
- [ ] Save multi-window, multi-tab arrangement → restore → all windows/tabs restored
- [ ] Save on dual monitors → disconnect external → restore → windows remap to primary
- [ ] Settings UI: rename, delete, reorder arrangements
- [ ] Auto-restore dropdown populated with saved arrangements; startup restore works
- [ ] `cargo test` passes (741 tests, 0 failures)
- [ ] `make lint` passes clean

Closes #103