### PR TITLE
feat(config): add import and export preferences support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Import/Export Preferences** (#91): Import and export terminal configuration
+  - Export current config to a YAML file via native file dialog
+  - Import preferences from a local YAML file (replace or merge modes)
+  - Import preferences from a URL (replace or merge modes)
+  - Merge mode only overrides values that differ from defaults, preserving user customizations
+  - Validation ensures imported config is well-formed before applying
+  - UI in Settings > Advanced > Import/Export Preferences
+
 ---
 
 ## [0.14.0] - 2026-02-11

--- a/MATRIX.md
+++ b/MATRIX.md
@@ -734,8 +734,8 @@ iTerm2 has sophisticated window state management.
 |---------|--------|----------|--------|--------|--------|-------|
 | Save preferences mode | ✅ `Save Preferences` | ✅ Auto-saves on change | ✅ | - | - | Auto-saves when settings changed in UI |
 | Preference file location | ✅ | ✅ XDG-compliant | ✅ | - | - | Already implemented |
-| Import preferences | ✅ | ❌ | ❌ | ⭐⭐ | 🟡 | Import from file/URL |
-| Export preferences | ✅ | ❌ | ❌ | ⭐⭐ | 🟢 | Export config to file |
+| Import preferences | ✅ | ✅ File & URL import | ✅ | - | - | Import from local file or URL with replace/merge modes |
+| Export preferences | ✅ | ✅ Export to YAML | ✅ | - | - | Export current config to YAML file via native dialog |
 | Preference validation | ✅ | ✅ Serde validation | ✅ | - | - | Serde deserialization with defaults and backward compat |
 | Preference profiles | ✅ | ✅ Full profile system | ✅ | - | - | Tags, inheritance, shortcuts, hostname/tmux auto-switching |
 | Shell integration download | ✅ | ✅ Embedded auto-install | ✅ | - | - | bash/zsh/fish scripts embedded and auto-installed to RC files |
@@ -926,7 +926,7 @@ Badges are semi-transparent text overlays displayed in the terminal corner showi
 | Image Protocol Enhancements | 9 | 0 | 0 |
 | Audio & Haptic Feedback | 2 | 0 | 3 |
 | Advanced GPU & Rendering Settings | 3 | 0 | 2 |
-| Advanced Configuration | 1 | 0 | 7 |
+| Advanced Configuration | 0 | 0 | 8 |
 | Unicode & Text Processing | 3 | 0 | 3 |
 | Browser Integration | 0 | 0 | 4 |
 | Progress Bars | 5 | 0 | 0 |
@@ -1075,9 +1075,8 @@ The following iTerm2 features were identified and added to the matrix in this up
 - User-based auto-switching
 - Dynamic profiles from URL with auto-reload
 
-**Advanced Configuration (7 features)**
+**Advanced Configuration (8 features)**
 - Save preferences mode (auto-save/ask on quit)
-- Import/export preferences
 - Preference validation and profiles
 
 **Unicode & Text Processing (2 features)**
@@ -1121,6 +1120,7 @@ The following iTerm2 features were identified and added to the matrix in this up
 - ✅ Shell integration event queuing (accurate OSC 133 marker positions)
 - ✅ Remember settings section expand/collapse states
 - ✅ Duplicate arrangement name overwrite prompt fix
+- ✅ Import/export preferences (file & URL import with replace/merge, YAML export)
 
 ### Previously Completed (v0.13.0)
 - ✅ Vi-style copy mode (full vi motions, visual selection, search, marks, status bar)

--- a/src/settings_ui/advanced_tab.rs
+++ b/src/settings_ui/advanced_tab.rs
@@ -3,6 +3,7 @@
 //! Consolidates: tmux_tab, logging_tab, screenshot_tab, update_tab
 //!
 //! Contains:
+//! - Import/export preferences
 //! - tmux integration settings
 //! - Session logging settings
 //! - Screenshot settings
@@ -10,7 +11,7 @@
 
 use super::SettingsUI;
 use super::section::{INPUT_WIDTH, collapsing_section};
-use crate::config::{LogLevel, SessionLogFormat, UpdateCheckFrequency};
+use crate::config::{Config, LogLevel, SessionLogFormat, UpdateCheckFrequency};
 use crate::update_checker::format_timestamp;
 use std::collections::HashSet;
 
@@ -22,6 +23,22 @@ pub fn show(
     collapsed: &mut HashSet<String>,
 ) {
     let query = settings.search_query.trim().to_lowercase();
+
+    // Import/Export Preferences section
+    if section_matches(
+        &query,
+        "Import/Export Preferences",
+        &[
+            "import",
+            "export",
+            "preferences",
+            "backup",
+            "restore",
+            "config",
+        ],
+    ) {
+        show_import_export_section(ui, settings, changes_this_frame, collapsed);
+    }
 
     // tmux Integration section
     if section_matches(
@@ -85,6 +102,302 @@ fn section_matches(query: &str, title: &str, keywords: &[&str]) -> bool {
         return true;
     }
     keywords.iter().any(|k| k.to_lowercase().contains(query))
+}
+
+// ============================================================================
+// Import/Export Preferences Section
+// ============================================================================
+
+fn show_import_export_section(
+    ui: &mut egui::Ui,
+    settings: &mut SettingsUI,
+    changes_this_frame: &mut bool,
+    collapsed: &mut HashSet<String>,
+) {
+    collapsing_section(
+        ui,
+        "Import/Export Preferences",
+        "advanced_import_export",
+        true,
+        collapsed,
+        |ui| {
+            ui.label("Export your current configuration or import settings from a file or URL.");
+            ui.add_space(8.0);
+
+            // --- Export ---
+            ui.label(egui::RichText::new("Export").strong());
+            ui.add_space(4.0);
+
+            if ui
+                .button("Export Preferences to File")
+                .on_hover_text("Save the current configuration to a YAML file")
+                .clicked()
+            {
+                export_preferences(settings);
+            }
+
+            ui.add_space(12.0);
+
+            // --- Import from File ---
+            ui.label(egui::RichText::new("Import from File").strong());
+            ui.add_space(4.0);
+
+            ui.horizontal(|ui| {
+                if ui
+                    .button("Import & Replace")
+                    .on_hover_text("Replace the entire configuration with settings from a file")
+                    .clicked()
+                {
+                    import_preferences_from_file(settings, changes_this_frame, ImportMode::Replace);
+                }
+
+                if ui
+                    .button("Import & Merge")
+                    .on_hover_text(
+                        "Merge settings from a file into the current configuration \
+                         (only overrides non-default values)",
+                    )
+                    .clicked()
+                {
+                    import_preferences_from_file(settings, changes_this_frame, ImportMode::Merge);
+                }
+            });
+
+            ui.add_space(12.0);
+
+            // --- Import from URL ---
+            ui.label(egui::RichText::new("Import from URL").strong());
+            ui.add_space(4.0);
+
+            ui.horizontal(|ui| {
+                ui.label("URL:");
+                ui.add(
+                    egui::TextEdit::singleline(&mut settings.temp_import_url)
+                        .desired_width(INPUT_WIDTH)
+                        .hint_text("https://example.com/config.yaml"),
+                );
+            });
+
+            ui.horizontal(|ui| {
+                let url_valid = !settings.temp_import_url.trim().is_empty()
+                    && (settings.temp_import_url.starts_with("http://")
+                        || settings.temp_import_url.starts_with("https://"));
+
+                if ui
+                    .add_enabled(url_valid, egui::Button::new("Fetch & Replace"))
+                    .on_hover_text("Download and replace the current configuration")
+                    .clicked()
+                {
+                    import_preferences_from_url(settings, changes_this_frame, ImportMode::Replace);
+                }
+
+                if ui
+                    .add_enabled(url_valid, egui::Button::new("Fetch & Merge"))
+                    .on_hover_text("Download and merge into the current configuration")
+                    .clicked()
+                {
+                    import_preferences_from_url(settings, changes_this_frame, ImportMode::Merge);
+                }
+            });
+
+            // Show status/error messages
+            if let Some(ref msg) = settings.import_export_status {
+                ui.add_space(4.0);
+                let color = if settings.import_export_is_error {
+                    egui::Color32::from_rgb(255, 100, 100)
+                } else {
+                    egui::Color32::from_rgb(100, 200, 100)
+                };
+                ui.label(egui::RichText::new(msg.as_str()).color(color));
+            }
+
+            ui.add_space(4.0);
+            ui.label(
+                egui::RichText::new(
+                    "Merge mode preserves your existing settings and only applies \
+                     values that differ from defaults in the imported file.",
+                )
+                .small()
+                .color(egui::Color32::GRAY),
+            );
+        },
+    );
+}
+
+/// Whether to replace or merge when importing preferences.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ImportMode {
+    /// Replace the entire configuration.
+    Replace,
+    /// Merge non-default values from the imported config.
+    Merge,
+}
+
+/// Export the current configuration to a YAML file.
+fn export_preferences(settings: &mut SettingsUI) {
+    let path = rfd::FileDialog::new()
+        .set_title("Export Preferences")
+        .add_filter("YAML", &["yaml", "yml"])
+        .set_file_name("par-term-config.yaml")
+        .save_file();
+
+    if let Some(path) = path {
+        match serde_yaml::to_string(&settings.config) {
+            Ok(yaml) => {
+                if let Err(e) = std::fs::write(&path, yaml) {
+                    settings.import_export_status = Some(format!("Failed to write file: {}", e));
+                    settings.import_export_is_error = true;
+                    log::error!("Failed to export preferences: {}", e);
+                } else {
+                    settings.import_export_status = Some(format!("Exported to {}", path.display()));
+                    settings.import_export_is_error = false;
+                    log::info!("Exported preferences to {}", path.display());
+                }
+            }
+            Err(e) => {
+                settings.import_export_status = Some(format!("Failed to serialize config: {}", e));
+                settings.import_export_is_error = true;
+                log::error!("Failed to serialize preferences: {}", e);
+            }
+        }
+    }
+}
+
+/// Import preferences from a local file.
+fn import_preferences_from_file(
+    settings: &mut SettingsUI,
+    changes_this_frame: &mut bool,
+    mode: ImportMode,
+) {
+    let path = rfd::FileDialog::new()
+        .set_title("Import Preferences")
+        .add_filter("YAML", &["yaml", "yml"])
+        .pick_file();
+
+    if let Some(path) = path {
+        match std::fs::read_to_string(&path) {
+            Ok(content) => {
+                apply_imported_config(settings, changes_this_frame, &content, mode);
+            }
+            Err(e) => {
+                settings.import_export_status = Some(format!("Failed to read file: {}", e));
+                settings.import_export_is_error = true;
+                log::error!("Failed to read preferences file: {}", e);
+            }
+        }
+    }
+}
+
+/// Import preferences from a URL.
+fn import_preferences_from_url(
+    settings: &mut SettingsUI,
+    changes_this_frame: &mut bool,
+    mode: ImportMode,
+) {
+    let url = settings.temp_import_url.trim().to_string();
+    if url.is_empty() {
+        return;
+    }
+
+    let agent = crate::http::agent();
+    match agent.get(&url).call() {
+        Ok(response) => match response.into_body().read_to_string() {
+            Ok(content) => {
+                apply_imported_config(settings, changes_this_frame, &content, mode);
+            }
+            Err(e) => {
+                settings.import_export_status = Some(format!("Failed to read response: {}", e));
+                settings.import_export_is_error = true;
+                log::error!("Failed to read URL response body: {}", e);
+            }
+        },
+        Err(e) => {
+            settings.import_export_status = Some(format!("Failed to fetch URL: {}", e));
+            settings.import_export_is_error = true;
+            log::error!("Failed to fetch preferences from URL: {}", e);
+        }
+    }
+}
+
+/// Parse YAML content as a Config and apply it to the settings.
+fn apply_imported_config(
+    settings: &mut SettingsUI,
+    changes_this_frame: &mut bool,
+    content: &str,
+    mode: ImportMode,
+) {
+    match serde_yaml::from_str::<Config>(content) {
+        Ok(imported) => {
+            match mode {
+                ImportMode::Replace => {
+                    settings.config = imported;
+                }
+                ImportMode::Merge => {
+                    merge_config(&mut settings.config, &imported);
+                }
+            }
+            settings.sync_all_temps_from_config();
+            settings.has_changes = true;
+            *changes_this_frame = true;
+            settings.import_export_status = Some(match mode {
+                ImportMode::Replace => "Configuration replaced successfully.".to_string(),
+                ImportMode::Merge => "Configuration merged successfully.".to_string(),
+            });
+            settings.import_export_is_error = false;
+            log::info!(
+                "Imported preferences (mode={:?})",
+                match mode {
+                    ImportMode::Replace => "replace",
+                    ImportMode::Merge => "merge",
+                }
+            );
+        }
+        Err(e) => {
+            settings.import_export_status = Some(format!("Invalid config file: {}", e));
+            settings.import_export_is_error = true;
+            log::error!("Failed to parse imported config: {}", e);
+        }
+    }
+}
+
+/// Merge an imported Config into the current config.
+///
+/// For each field, if the imported value differs from the default, it overwrites
+/// the current value. This lets users share partial configs that only override
+/// specific settings.
+pub fn merge_config(current: &mut Config, imported: &Config) {
+    let defaults = Config::default();
+
+    // Serialize all three to serde_yaml::Value for field-by-field comparison
+    let default_val: serde_yaml::Value =
+        serde_yaml::from_str(&serde_yaml::to_string(&defaults).unwrap_or_default())
+            .unwrap_or(serde_yaml::Value::Null);
+    let imported_val: serde_yaml::Value =
+        serde_yaml::from_str(&serde_yaml::to_string(imported).unwrap_or_default())
+            .unwrap_or(serde_yaml::Value::Null);
+    let mut current_val: serde_yaml::Value =
+        serde_yaml::from_str(&serde_yaml::to_string(&*current).unwrap_or_default())
+            .unwrap_or(serde_yaml::Value::Null);
+
+    if let (
+        serde_yaml::Value::Mapping(ref default_map),
+        serde_yaml::Value::Mapping(ref imported_map),
+        serde_yaml::Value::Mapping(current_map),
+    ) = (default_val, imported_val, &mut current_val)
+    {
+        for (key, imported_field) in imported_map {
+            let default_field = default_map.get(key);
+            // Only override if the imported value differs from the default
+            if default_field != Some(imported_field) {
+                current_map.insert(key.clone(), imported_field.clone());
+            }
+        }
+    }
+
+    // Deserialize the merged value back into Config
+    if let Ok(merged) = serde_yaml::from_value::<Config>(current_val) {
+        *current = merged;
+    }
 }
 
 // ============================================================================

--- a/src/settings_ui/mod.rs
+++ b/src/settings_ui/mod.rs
@@ -322,6 +322,14 @@ pub struct SettingsUI {
     /// Recorded keybinding combo for action (displayed during recording)
     pub(crate) action_recorded_combo: Option<String>,
 
+    // Import/export preferences state
+    /// Temporary URL for import-from-URL feature
+    pub(crate) temp_import_url: String,
+    /// Status message for import/export operations
+    pub(crate) import_export_status: Option<String>,
+    /// Whether the import/export status is an error (true) or success (false)
+    pub(crate) import_export_is_error: bool,
+
     // Reset to defaults dialog state
     /// Whether to show the reset to defaults confirmation dialog
     pub(crate) show_reset_defaults_dialog: bool,
@@ -489,6 +497,9 @@ impl SettingsUI {
             snippet_recorded_combo: None,
             recording_action_keybinding: false,
             action_recorded_combo: None,
+            temp_import_url: String::new(),
+            import_export_status: None,
+            import_export_is_error: false,
             show_reset_defaults_dialog: false,
             arrangement_save_name: String::new(),
             arrangement_confirm_restore: None,
@@ -570,8 +581,8 @@ impl SettingsUI {
         self.font_pending_changes = false;
     }
 
-    /// Sync ALL temp fields from config (used when resetting to defaults)
-    fn sync_all_temps_from_config(&mut self) {
+    /// Sync ALL temp fields from config (used when resetting to defaults or importing)
+    pub(crate) fn sync_all_temps_from_config(&mut self) {
         // Font temps
         self.sync_font_temps_from_config();
 

--- a/tests/import_export_tests.rs
+++ b/tests/import_export_tests.rs
@@ -1,0 +1,115 @@
+//! Tests for import/export preferences functionality.
+
+#![allow(clippy::field_reassign_with_default)]
+
+use par_term::config::Config;
+use par_term::settings_ui::advanced_tab::merge_config;
+
+#[test]
+fn test_export_config_round_trip() {
+    let config = Config::default();
+    let yaml = serde_yaml::to_string(&config).expect("serialize");
+    let imported: Config = serde_yaml::from_str(&yaml).expect("deserialize");
+    assert_eq!(config.cols, imported.cols);
+    assert_eq!(config.rows, imported.rows);
+    assert_eq!(config.font_size, imported.font_size);
+    assert_eq!(config.font_family, imported.font_family);
+    assert_eq!(config.theme, imported.theme);
+}
+
+#[test]
+fn test_import_replace_overrides_all_fields() {
+    let yaml = r#"
+cols: 120
+rows: 40
+font_size: 18.0
+font_family: "Fira Code"
+"#;
+    let imported: Config = serde_yaml::from_str(yaml).expect("parse imported");
+
+    // Replace mode: entire config is the imported one
+    assert_eq!(imported.cols, 120);
+    assert_eq!(imported.rows, 40);
+    assert_eq!(imported.font_size, 18.0);
+    assert_eq!(imported.font_family, "Fira Code");
+}
+
+#[test]
+fn test_merge_config_only_overrides_non_defaults() {
+    let mut current = Config::default();
+    current.cols = 100; // User's custom value
+    current.rows = 30; // User's custom value
+
+    // Imported config only changes font_size (non-default value)
+    let mut imported = Config::default();
+    imported.font_size = 18.0;
+    // cols and rows are still defaults (80, 24) in imported
+
+    merge_config(&mut current, &imported);
+
+    // font_size should be overridden (imported differs from default)
+    assert_eq!(current.font_size, 18.0);
+    // cols and rows should be preserved (imported values match defaults)
+    assert_eq!(current.cols, 100);
+    assert_eq!(current.rows, 30);
+}
+
+#[test]
+fn test_merge_config_preserves_current_when_imported_is_default() {
+    let mut current = Config::default();
+    current.font_family = "Hack".to_string();
+    current.theme = "my-custom-theme".to_string();
+
+    let imported = Config::default(); // All defaults
+
+    merge_config(&mut current, &imported);
+
+    // Nothing should change since all imported values match defaults
+    assert_eq!(current.font_family, "Hack");
+    assert_eq!(current.theme, "my-custom-theme");
+}
+
+#[test]
+fn test_merge_config_overrides_multiple_non_default_fields() {
+    let mut current = Config::default();
+    current.cols = 100;
+
+    let mut imported = Config::default();
+    imported.font_size = 16.0;
+    imported.font_family = "Fira Code".to_string();
+    imported.scrollback_lines = 50000;
+
+    merge_config(&mut current, &imported);
+
+    // All non-default imported values should be applied
+    assert_eq!(current.font_size, 16.0);
+    assert_eq!(current.font_family, "Fira Code");
+    assert_eq!(current.scrollback_lines, 50000);
+    // Current's custom cols should be preserved
+    assert_eq!(current.cols, 100);
+}
+
+#[test]
+fn test_import_partial_yaml_uses_defaults_for_missing_fields() {
+    let yaml = r#"
+font_size: 20.0
+theme: "solarized-dark"
+"#;
+    let imported: Config = serde_yaml::from_str(yaml).expect("parse partial yaml");
+
+    // Explicitly set fields should match
+    assert_eq!(imported.font_size, 20.0);
+    assert_eq!(imported.theme, "solarized-dark");
+
+    // Missing fields should use defaults
+    assert_eq!(imported.cols, 80);
+    assert_eq!(imported.rows, 24);
+    assert_eq!(imported.font_family, "JetBrains Mono");
+}
+
+#[test]
+fn test_import_invalid_yaml_returns_error() {
+    let yaml = "this is not: valid: yaml: {{{";
+    let result = serde_yaml::from_str::<Config>(yaml);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

- Add import/export configuration UI in Settings > Advanced > Import/Export Preferences
- Export current configuration to a YAML file via native save dialog
- Import preferences from a local YAML file with **replace** or **merge** modes
- Import preferences from a URL with **replace** or **merge** modes
- Merge mode uses YAML value comparison against defaults to only override non-default fields, preserving user customizations
- Added 7 integration tests covering merge logic, round-trip serialization, partial YAML import, and error handling

Closes #91

## Test plan

- [x] All existing tests pass (`cargo test` - 19 passed, 0 failed)
- [x] 7 new import/export tests pass (`cargo test --test import_export_tests`)
- [x] `cargo clippy` clean (no warnings)
- [x] `cargo fmt` clean
- [x] Release build succeeds
- [ ] Manual test: export config, verify YAML output matches current settings
- [ ] Manual test: import from file (replace mode), verify all settings change
- [ ] Manual test: import from file (merge mode), verify only non-default values apply
- [ ] Manual test: import from URL with a raw GitHub config URL