### PR TITLE
fix: eliminate double build in make bundle-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,10 +189,11 @@ clean:
 	@echo "Cleaning build artifacts..."
 	cargo clean
 
-# Install the binary
-install:
-	@echo "Installing par-term..."
-	cargo install --path . --bin par-term
+# Install the binary (reuses release build)
+install: release
+	@echo "Installing par-term to ~/.cargo/bin/..."
+	@cp target/release/par-term "$${HOME}/.cargo/bin/par-term"
+	@echo "Installed to ~/.cargo/bin/par-term"
 
 # Generate documentation
 doc:


### PR DESCRIPTION
## Summary
- `make bundle-install` was building the Rust binary twice: once via `cargo build --release` (through the `bundle` dependency) and again via `cargo install --path .` (through the `install` dependency)
- Changed `install` target to depend on `release` and copy the already-built binary to `~/.cargo/bin/` instead of rebuilding

## Test plan
- [ ] Run `make install` — verify it builds once and copies to `~/.cargo/bin/par-term`
- [ ] Run `make bundle-install` — verify only one compilation pass occurs
- [ ] Verify installed binary works: `~/.cargo/bin/par-term --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)