### PR TITLE
feat(profiles): add directory-based automatic profile switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Settings UI for editing directory patterns per profile
   - Does not override explicit user profile selection or hostname-based switching
 
+- **Profile Emoji Picker** (#114): Emoji picker popup for the profile icon field in the profile modal
+  - Curated grid of ~70 terminal-relevant emojis in 9 categories (Terminal, Dev & Tools, Files & Data, Network & Cloud, Security, Status & Alerts, Containers & Infra, People & Roles, Misc)
+  - Scrollable popup with category headers and one-click selection
+  - Users can still type custom emojis directly in the text field
+  - "Clear icon" button to remove the current icon
+
+- **Full Profile Auto-Switch Application** (#114): Auto-switched profiles now apply all visual settings
+  - **Directory switching**: Applies profile icon in tab bar, overrides tab title, applies badge text and badge styling (color, alpha, font, bold, margins, size), executes profile command
+  - **Hostname switching**: Brought to full parity — applies icon, title, badge text/styling, and command execution on remote host detection
+  - **Tmux session switching**: Brought to full parity — applies icon, title, badge text/styling, and command execution on session name match
+  - Profile icon displayed in both horizontal and vertical tab bar layouts
+  - Original tab title saved and restored when auto-profile clears
+
 - **Tab Style Variants** (#112): Cosmetic tab bar presets with 5 built-in styles
   - Dark (default), Light, Compact, Minimal, and High Contrast presets
   - Each preset applies coordinated color/size/spacing adjustments
@@ -90,6 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Paste/Copy/Select-All in egui overlays**: Cmd+V, Cmd+C, and Cmd+A now correctly route to egui text fields when a modal dialog is active (profile modal, search overlay, clipboard history, command history, shader install, integrations). Previously, macOS menu accelerators (muda) intercepted these shortcuts and sent them to the terminal instead.
+- **Directory pattern tilde expansion**: Profile directory patterns using `~` (e.g., `~/Repos/par-term*`) now correctly expand to the home directory before matching. Previously, `~` was treated as a literal character and never matched.
 - **Comprehensive HiDPI/DPI scaling fix**: All pixel-dimension config values are now correctly scaled from logical pixels to physical pixels on HiDPI displays (e.g., Retina at scale_factor=2). Previously, many values rendered at half their intended size. Fixed values include:
   - Tab bar content offset (#121), window padding, scrollbar width
   - Pane padding, divider width/hit width, title height, focus border width

--- a/MATRIX.md
+++ b/MATRIX.md
@@ -287,7 +287,7 @@ This document compares features between iTerm2 and par-term, including assessmen
 | Profile selection | ✅ GUI + keyboard | ✅ Drawer + Modal | ✅ | - | - | Collapsible drawer, double-click to open |
 | Profile creation/editing | ✅ | ✅ Modal UI | ✅ | - | - | Full CRUD operations |
 | Profile reordering | ✅ | ✅ Move up/down | ✅ | - | - | Drag-free reorder buttons |
-| Profile icon | ✅ Custom icons | ✅ Emoji icons | ✅ | - | - | Visual identification with emoji |
+| Profile icon | ✅ Custom icons | ✅ Emoji icons + picker | ✅ | - | - | Emoji picker with ~70 curated icons in 9 categories; icon shown in tab bar |
 | Working directory | ✅ | ✅ Per-profile | ✅ | - | - | With directory browser |
 | Custom command | ✅ | ✅ Per-profile | ✅ | - | - | Command + arguments |
 | Custom tab name | ✅ | ✅ Per-profile | ✅ | - | - | Override default tab naming |
@@ -295,7 +295,7 @@ This document compares features between iTerm2 and par-term, including assessmen
 | Profile tags | ✅ Searchable tags | ✅ `tags` | ✅ | - | - | Filter/search profiles by tags in drawer |
 | Profile inheritance | ✅ Parent profiles | ✅ `parent_id` | ✅ | - | - | Child inherits parent settings, can override |
 | Profile keyboard shortcut | ✅ | ✅ `keyboard_shortcut` | ✅ | - | - | Quick profile launch via hotkey (e.g., "Cmd+1") |
-| Automatic profile switching | ✅ Based on hostname | ✅ `hostname_patterns`, `directory_patterns` | ✅ | - | - | OSC 7 hostname and CWD detection triggers profile match |
+| Automatic profile switching | ✅ Based on hostname | ✅ `hostname_patterns`, `directory_patterns` | ✅ | - | - | OSC 7 hostname and CWD detection triggers profile match; applies icon, title, badge, command |
 | Profile badge | ✅ `Badge Text` | ✅ `badge_text` | ✅ | - | - | Per-profile badge format override + session.profile_name |
 
 ---
@@ -386,7 +386,7 @@ par-term implements iTerm2-style native tmux integration via control mode (`tmux
 | tmux clipboard sync | ✅ Bidirectional | ✅ `set-buffer` | ✅ | - | - | Sync with tmux paste buffers |
 | tmux pause mode handling | ✅ | ✅ | ✅ | - | - | Handle slow connection pausing with buffering |
 | Auto-attach on launch | ✅ | ✅ `tmux_auto_attach` | ✅ | - | - | Option to auto-attach to session |
-| tmux profile auto-switching | ✅ | ✅ | ✅ | - | - | Glob pattern matching on session names (e.g., `work-*`, `*-production`) |
+| tmux profile auto-switching | ✅ | ✅ | ✅ | - | - | Glob pattern matching on session names; applies icon, title, badge styling, command |
 
 ### How par-term's tmux Control Mode Works
 
@@ -411,7 +411,7 @@ par-term implements iTerm2-style native tmux integration via control mode (`tmux
 - `tmux_status_bar_left`: Format string for left side (default: `[{session}] {windows}`)
 - `tmux_status_bar_right`: Format string for right side (default: `{pane} | {time:%H:%M}`)
 - `tmux_status_bar_use_native_format`: Use native tmux format strings (queries tmux directly)
-- `tmux_profile`: Profile to use when connected (pending)
+- `tmux_profile`: Profile to use when connected (auto-switching applies full visual settings)
 
 ---
 
@@ -676,8 +676,8 @@ iTerm2 has sophisticated window state management.
 
 | Feature | iTerm2 | par-term | Status | Useful | Effort | Notes |
 |---------|--------|----------|--------|--------|--------|-------|
-| Hostname-based switching | ✅ | ✅ | ✅ | - | - | Already implemented |
-| Directory-based switching | ✅ | ✅ `directory_patterns` | ✅ | - | - | Auto-switch profile by CWD via OSC 7 |
+| Hostname-based switching | ✅ | ✅ | ✅ | - | - | Full parity: applies icon, title, badge text/styling, command execution |
+| Directory-based switching | ✅ | ✅ `directory_patterns` | ✅ | - | - | Full parity: applies icon, title, badge text/styling, command execution; tilde expansion |
 | Command-based switching | ✅ | ❌ | ❌ | ⭐ | 🟡 | Auto-switch by running command |
 | User-based switching | ✅ | ❌ | ❌ | ⭐ | 🟡 | Switch by SSH user |
 | Dynamic profiles from URL | ✅ `Dynamic Profiles` | ❌ | ❌ | ⭐⭐ | 🔴 | Load profiles from remote URL |

--- a/src/app/window_manager.rs
+++ b/src/app/window_manager.rs
@@ -885,6 +885,14 @@ impl WindowManager {
                     }
                     return;
                 }
+                // If an egui overlay (profile modal, search, etc.) is active, inject into main egui
+                if let Some(window_id) = focused_window
+                    && let Some(window_state) = self.windows.get_mut(&window_id)
+                    && window_state.has_egui_overlay_visible()
+                {
+                    window_state.pending_egui_events.push(egui::Event::Copy);
+                    return;
+                }
                 if let Some(window_id) = focused_window
                     && let Some(window_state) = self.windows.get_mut(&window_id)
                     && let Some(text) = window_state.get_selected_text()
@@ -911,6 +919,20 @@ impl WindowManager {
                     }
                     return;
                 }
+                // If an egui overlay (profile modal, search, etc.) is active, inject into main egui
+                if let Some(window_id) = focused_window
+                    && let Some(window_state) = self.windows.get_mut(&window_id)
+                    && window_state.has_egui_overlay_visible()
+                {
+                    if let Ok(mut clipboard) = arboard::Clipboard::new()
+                        && let Ok(text) = clipboard.get_text()
+                    {
+                        window_state
+                            .pending_egui_events
+                            .push(egui::Event::Paste(text));
+                    }
+                    return;
+                }
                 if let Some(window_id) = focused_window
                     && let Some(window_state) = self.windows.get_mut(&window_id)
                     && let Some(text) = window_state.input_handler.paste_from_clipboard()
@@ -933,6 +955,20 @@ impl WindowManager {
                             modifiers: egui::Modifiers::COMMAND,
                         });
                     }
+                    return;
+                }
+                // If an egui overlay is active, inject select-all into main egui
+                if let Some(window_id) = focused_window
+                    && let Some(window_state) = self.windows.get_mut(&window_id)
+                    && window_state.has_egui_overlay_visible()
+                {
+                    window_state.pending_egui_events.push(egui::Event::Key {
+                        key: egui::Key::A,
+                        physical_key: None,
+                        pressed: true,
+                        repeat: false,
+                        modifiers: egui::Modifiers::COMMAND,
+                    });
                     return;
                 }
                 // Not implemented for terminal - would select all visible text

--- a/src/profile_modal_ui.rs
+++ b/src/profile_modal_ui.rs
@@ -4,6 +4,43 @@
 
 use crate::profile::{Profile, ProfileId, ProfileManager};
 
+/// Curated emoji presets organized by category for the profile icon picker
+const EMOJI_PRESETS: &[(&str, &[&str])] = &[
+    (
+        "Terminal",
+        &["💻", "🖥️", "⌨️", "🐚", "📟", "🔲", "▶️", "⬛"],
+    ),
+    (
+        "Dev & Tools",
+        &["🔧", "🛠️", "⚙️", "🔨", "🧰", "📐", "🔬", "🧪"],
+    ),
+    (
+        "Files & Data",
+        &["📁", "📂", "📄", "📊", "💾", "🗄️", "📦", "🗃️"],
+    ),
+    (
+        "Network & Cloud",
+        &["🌐", "☁️", "📡", "🔗", "🌍", "📶", "🛰️", "🌎"],
+    ),
+    (
+        "Security",
+        &["🔒", "🔑", "🛡️", "🔐", "🚨", "⚠️", "🔓", "🧱"],
+    ),
+    (
+        "Status & Alerts",
+        &["✅", "❌", "⚡", "🔔", "💡", "🚀", "🎯", "🔥"],
+    ),
+    (
+        "Containers & Infra",
+        &["🐳", "🐧", "🏗️", "📀", "🧊", "📋", "🔄", "🏠"],
+    ),
+    (
+        "People & Roles",
+        &["👤", "👨‍💻", "👩‍💻", "🤖", "👥", "🧑‍🔧", "🧑‍🏫", "👷"],
+    ),
+    ("Misc", &["🎨", "📝", "🏷️", "⭐", "💎", "🌈", "🎮", "🎵"]),
+];
+
 /// Actions that can be triggered from the profile modal
 #[derive(Debug, Clone, PartialEq)]
 pub enum ProfileModalAction {
@@ -639,11 +676,52 @@ impl ProfileModalUI {
                         ui.label("Icon:");
                         ui.horizontal(|ui| {
                             ui.text_edit_singleline(&mut self.temp_icon);
-                            ui.label(
-                                egui::RichText::new("(emoji)")
-                                    .small()
-                                    .color(egui::Color32::GRAY),
-                            );
+                            let picker_label = if self.temp_icon.is_empty() {
+                                "😀"
+                            } else {
+                                &self.temp_icon
+                            };
+                            let picker_btn = ui.button(picker_label);
+                            egui::Popup::from_toggle_button_response(&picker_btn)
+                                .close_behavior(
+                                    egui::PopupCloseBehavior::CloseOnClickOutside,
+                                )
+                                .show(|ui| {
+                                    ui.set_min_width(280.0);
+                                    egui::ScrollArea::vertical()
+                                        .max_height(300.0)
+                                        .show(ui, |ui| {
+                                            for (category, emojis) in EMOJI_PRESETS {
+                                                ui.label(
+                                                    egui::RichText::new(*category)
+                                                        .small()
+                                                        .strong(),
+                                                );
+                                                ui.horizontal_wrapped(|ui| {
+                                                    for emoji in *emojis {
+                                                        let btn = ui.add_sized(
+                                                            [28.0, 28.0],
+                                                            egui::Button::new(*emoji)
+                                                                .frame(false),
+                                                        );
+                                                        if btn.clicked() {
+                                                            self.temp_icon =
+                                                                emoji.to_string();
+                                                            egui::Popup::close_all(
+                                                                ui.ctx(),
+                                                            );
+                                                        }
+                                                    }
+                                                });
+                                                ui.add_space(2.0);
+                                            }
+                                            ui.add_space(4.0);
+                                            if ui.button("Clear icon").clicked() {
+                                                self.temp_icon.clear();
+                                                egui::Popup::close_all(ui.ctx());
+                                            }
+                                        });
+                                });
                         });
                         ui.end_row();
 

--- a/src/tab/mod.rs
+++ b/src/tab/mod.rs
@@ -346,6 +346,10 @@ pub struct Tab {
     pub auto_applied_profile_id: Option<crate::profile::ProfileId>,
     /// Profile ID that was auto-applied based on directory pattern matching
     pub auto_applied_dir_profile_id: Option<crate::profile::ProfileId>,
+    /// Icon from auto-applied profile (displayed in tab bar)
+    pub profile_icon: Option<String>,
+    /// Original tab title saved before auto-profile override (restored when profile clears)
+    pub pre_profile_title: Option<String>,
     /// Badge text override from auto-applied profile (overrides global badge_format)
     pub badge_override: Option<String>,
     /// Mapping from config index to coprocess ID (for UI tracking)
@@ -536,6 +540,8 @@ impl Tab {
             detected_cwd: None,
             auto_applied_profile_id: None,
             auto_applied_dir_profile_id: None,
+            profile_icon: None,
+            pre_profile_title: None,
             badge_override: None,
             coprocess_ids,
             trigger_marks: Vec::new(),
@@ -727,6 +733,8 @@ impl Tab {
             detected_cwd: None,
             auto_applied_profile_id: None,
             auto_applied_dir_profile_id: None,
+            profile_icon: None,
+            pre_profile_title: None,
             badge_override: None,
             coprocess_ids,
             trigger_marks: Vec::new(),
@@ -920,6 +928,10 @@ impl Tab {
     pub fn clear_auto_profile(&mut self) {
         self.auto_applied_profile_id = None;
         self.auto_applied_dir_profile_id = None;
+        self.profile_icon = None;
+        if let Some(original) = self.pre_profile_title.take() {
+            self.title = original;
+        }
         self.badge_override = None;
     }
 
@@ -1416,6 +1428,8 @@ impl Tab {
             detected_cwd: None,
             auto_applied_profile_id: None,
             auto_applied_dir_profile_id: None,
+            profile_icon: None,
+            pre_profile_title: None,
             badge_override: None,
             coprocess_ids: Vec::new(),
             trigger_marks: Vec::new(),

--- a/src/tab_bar_ui.rs
+++ b/src/tab_bar_ui.rs
@@ -237,6 +237,7 @@ impl TabBarUI {
                                         tab.id,
                                         index,
                                         &tab.title,
+                                        tab.profile_icon.as_deref(),
                                         is_active,
                                         tab.has_activity,
                                         is_bell_active,
@@ -279,6 +280,7 @@ impl TabBarUI {
                             tab.id,
                             index,
                             &tab.title,
+                            tab.profile_icon.as_deref(),
                             is_active,
                             tab.has_activity,
                             is_bell_active,
@@ -380,6 +382,7 @@ impl TabBarUI {
                                     tab.id,
                                     index,
                                     &tab.title,
+                                    tab.profile_icon.as_deref(),
                                     is_active,
                                     tab.has_activity,
                                     is_bell_active,
@@ -447,6 +450,7 @@ impl TabBarUI {
         id: TabId,
         _index: usize,
         title: &str,
+        profile_icon: Option<&str>,
         is_active: bool,
         has_activity: bool,
         is_bell_active: bool,
@@ -553,6 +557,15 @@ impl TabBarUI {
                     ui.add_space(2.0);
                 }
 
+                // Profile icon
+                let icon_width = if let Some(icon) = profile_icon {
+                    ui.label(icon);
+                    ui.add_space(2.0);
+                    18.0
+                } else {
+                    0.0
+                };
+
                 let text_color = if is_active {
                     let c = config.tab_active_text;
                     egui::Color32::from_rgba_unmultiplied(c[0], c[1], c[2], 255)
@@ -567,7 +580,7 @@ impl TabBarUI {
                 } else {
                     0.0
                 };
-                let available = (full_width - 16.0 - close_width).max(20.0);
+                let available = (full_width - 16.0 - icon_width - close_width).max(20.0);
                 let base_font_id = ui.style().text_styles[&egui::TextStyle::Button].clone();
                 let max_chars = estimate_max_chars(ui, &base_font_id, available);
                 let display_title = truncate_plain(title, max_chars);
@@ -761,6 +774,7 @@ impl TabBarUI {
         id: TabId,
         index: usize,
         title: &str,
+        profile_icon: Option<&str>,
         is_active: bool,
         has_activity: bool,
         is_bell_active: bool,
@@ -897,6 +911,15 @@ impl TabBarUI {
                     // We'd need to get the index, skip for now
                 }
 
+                // Profile icon (from auto-applied directory/hostname profile)
+                let icon_width = if let Some(icon) = profile_icon {
+                    ui.label(icon);
+                    ui.add_space(2.0);
+                    18.0
+                } else {
+                    0.0
+                };
+
                 // Title rendering with width-aware truncation
                 let base_font_id = ui.style().text_styles[&egui::TextStyle::Button].clone();
                 let indicator_width = if is_bell_active {
@@ -913,8 +936,13 @@ impl TabBarUI {
                     0.0
                 };
                 let padding = 12.0;
-                let title_available_width =
-                    (tab_width - indicator_width - hotkey_width - close_width - padding).max(24.0);
+                let title_available_width = (tab_width
+                    - indicator_width
+                    - icon_width
+                    - hotkey_width
+                    - close_width
+                    - padding)
+                    .max(24.0);
 
                 let max_chars = estimate_max_chars(ui, &base_font_id, title_available_width);
 


### PR DESCRIPTION
## Summary
- Adds `directory_patterns` field to profiles for automatic CWD-based profile switching
- Monitors CWD changes via OSC 7 and matches against glob patterns (e.g., `/Users/*/projects/work-*`)
- Priority order: explicit user selection > hostname match > directory match > default
- Settings UI for editing directory patterns per profile in the profile modal
- 7 new tests covering pattern matching, serialization, inheritance, and profile lookup

## Changes
- `src/profile/types.rs`: Added `directory_patterns` field, `find_by_directory()`, `directory_pattern_matches()`, builder method, inheritance support, and tests
- `src/app/tab_ops.rs`: Refactored `check_auto_profile_switch()` into hostname and directory sub-checks
- `src/tab/mod.rs`: Added `detected_cwd` and `auto_applied_dir_profile_id` tracking, `check_cwd_change()` method
- `src/profile_modal_ui.rs`: Added "Auto-Switch Dirs" field to profile edit form
- `MATRIX.md`: Updated §32 Profile Switching to reflect implementation
- `CHANGELOG.md`: Added entry for directory-based profile switching

## Test plan
- [x] All 421 existing tests pass
- [x] 7 new tests for directory pattern matching, lookup, serialization, inheritance
- [x] Clippy passes with no warnings
- [x] Formatting passes

Closes #114