### PR TITLE
feat(profiles): move profile management UI to settings window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+- **Profile management moved to Settings window** (#125): Profile create/edit/delete/reorder UI is now embedded inline in the Settings > Profiles tab, replacing the terminal-window modal dialog. The profile drawer's "Manage" button and the menu's "Manage Profiles" action now open the Settings window to the Profiles tab. This eliminates the disjointed settings → terminal → modal flow.
 - **Settings quick search**: Added missing search keywords across all settings tabs for better discoverability of settings via the search box
 
 ### Fixed

--- a/MATRIX.md
+++ b/MATRIX.md
@@ -284,8 +284,8 @@ This document compares features between iTerm2 and par-term, including assessmen
 | Feature | iTerm2 | par-term | Status | Useful | Effort | Notes |
 |---------|--------|----------|--------|--------|--------|-------|
 | Multiple profiles | ✅ Full profile system | ✅ `ProfileManager` | ✅ | - | - | Named configurations with YAML persistence |
-| Profile selection | ✅ GUI + keyboard | ✅ Drawer + Modal | ✅ | - | - | Collapsible drawer, double-click to open |
-| Profile creation/editing | ✅ | ✅ Modal UI | ✅ | - | - | Full CRUD operations |
+| Profile selection | ✅ GUI + keyboard | ✅ Drawer + Settings UI | ✅ | - | - | Collapsible drawer, inline management in Settings Profiles tab |
+| Profile creation/editing | ✅ | ✅ Settings UI | ✅ | - | - | Full CRUD operations inline in Settings window Profiles tab |
 | Profile reordering | ✅ | ✅ Move up/down | ✅ | - | - | Drag-free reorder buttons |
 | Profile icon | ✅ Custom icons | ✅ Emoji icons + picker | ✅ | - | - | Emoji picker with ~70 curated icons in 9 categories; icon shown in tab bar |
 | Working directory | ✅ | ✅ Per-profile | ✅ | - | - | With directory browser |

--- a/src/app/input_events.rs
+++ b/src/app/input_events.rs
@@ -19,7 +19,6 @@ impl WindowState {
             || self.clipboard_history_ui.visible
             || self.command_history_ui.visible
             || self.search_ui.visible
-            || self.profile_modal_ui.visible
             || self.tmux_session_picker_ui.visible;
 
         // When UI panels are visible, block ALL keys from going to terminal

--- a/src/app/mouse_events.rs
+++ b/src/app/mouse_events.rs
@@ -63,8 +63,8 @@ impl WindowState {
             .map(|t| t.mouse.position)
             .unwrap_or((0.0, 0.0));
 
-        // Check if profile modal or drawer is open - let egui handle all mouse events
-        if self.profile_modal_ui.visible || self.profile_drawer_ui.expanded {
+        // Check if profile drawer is open - let egui handle all mouse events
+        if self.profile_drawer_ui.expanded {
             if let Some(window) = &self.window {
                 window.request_redraw();
             }
@@ -535,8 +535,8 @@ impl WindowState {
             tab.mouse.position = position;
         }
 
-        // Check if profile modal or drawer is open - let egui handle mouse events
-        if self.profile_modal_ui.visible || self.profile_drawer_ui.expanded {
+        // Check if profile drawer is open - let egui handle mouse events
+        if self.profile_drawer_ui.expanded {
             if let Some(window) = &self.window {
                 window.request_redraw();
             }
@@ -803,8 +803,8 @@ impl WindowState {
     }
 
     pub(crate) fn handle_mouse_wheel(&mut self, delta: MouseScrollDelta) {
-        // Check if profile modal or drawer is open - let egui handle scroll events
-        if self.profile_modal_ui.visible || self.profile_drawer_ui.expanded {
+        // Check if profile drawer is open - let egui handle scroll events
+        if self.profile_drawer_ui.expanded {
             if let Some(window) = &self.window {
                 window.request_redraw();
             }

--- a/src/app/window_manager.rs
+++ b/src/app/window_manager.rs
@@ -1146,16 +1146,10 @@ impl WindowManager {
                 }
             }
             MenuAction::ManageProfiles => {
-                if let Some(window_id) = focused_window
-                    && let Some(window_state) = self.windows.get_mut(&window_id)
-                {
-                    window_state
-                        .profile_modal_ui
-                        .open(&window_state.profile_manager);
-                    window_state.needs_redraw = true;
-                    if let Some(window) = &window_state.window {
-                        window.request_redraw();
-                    }
+                self.open_settings_window(event_loop);
+                if let Some(sw) = &mut self.settings_window {
+                    sw.settings_ui
+                        .set_selected_tab(crate::settings_ui::sidebar::SettingsTab::Profiles);
                 }
             }
             MenuAction::ToggleProfileDrawer => {
@@ -1237,6 +1231,14 @@ impl WindowManager {
                 log::info!("Opened settings window {:?}", settings_window.window_id());
                 // Sync last update check result to settings UI
                 settings_window.settings_ui.last_update_result = self.last_update_result.clone();
+                // Sync profiles from first window's profile manager
+                let profiles = self
+                    .windows
+                    .values()
+                    .next()
+                    .map(|ws| ws.profile_manager.to_vec())
+                    .unwrap_or_default();
+                settings_window.settings_ui.sync_profiles(profiles);
                 self.settings_window = Some(settings_window);
                 // Sync arrangement data to settings UI
                 self.sync_arrangements_to_settings();

--- a/src/settings_ui/profiles_tab.rs
+++ b/src/settings_ui/profiles_tab.rs
@@ -1,12 +1,12 @@
 //! Profiles settings tab.
 //!
 //! Contains:
-//! - Overview of profile features
-//! - Button to open the profile manager modal
-//! - Profile list preview (read-only)
+//! - Inline profile management (create, edit, delete, reorder)
+//! - Display options for the profile drawer
 
 use super::SettingsUI;
 use super::section::collapsing_section;
+use crate::profile_modal_ui::ProfileModalAction;
 use std::collections::HashSet;
 
 /// Show the profiles tab content.
@@ -18,10 +18,10 @@ pub fn show(
 ) {
     let query = settings.search_query.trim().to_lowercase();
 
-    // Overview section
+    // Profile management section (inline)
     if section_matches(
         &query,
-        "Overview",
+        "Profile Management",
         &[
             "profile",
             "manage",
@@ -32,26 +32,7 @@ pub fn show(
             "default",
         ],
     ) {
-        show_overview_section(ui, settings, collapsed);
-    }
-
-    // Features section
-    if section_matches(
-        &query,
-        "Profile Features",
-        &[
-            "tags",
-            "inheritance",
-            "shortcut",
-            "keyboard",
-            "auto switch",
-            "hostname",
-            "tmux",
-            "session",
-            "badge",
-        ],
-    ) {
-        show_features_section(ui, collapsed);
+        show_management_section(ui, settings, collapsed);
     }
 
     // Display options section
@@ -82,10 +63,10 @@ fn section_matches(query: &str, title: &str, keywords: &[&str]) -> bool {
 }
 
 // ============================================================================
-// Overview Section
+// Profile Management Section (inline)
 // ============================================================================
 
-fn show_overview_section(
+fn show_management_section(
     ui: &mut egui::Ui,
     settings: &mut SettingsUI,
     collapsed: &mut HashSet<String>,
@@ -93,90 +74,23 @@ fn show_overview_section(
     collapsing_section(
         ui,
         "Profile Management",
-        "profiles_overview",
+        "profiles_management",
         true,
         collapsed,
         |ui| {
-            ui.label("Profiles allow you to save and quickly switch between different terminal configurations.");
-            ui.add_space(8.0);
+            // Render the profile list/edit UI inline
+            let action = settings.profile_modal_ui.show_inline(ui);
 
-            ui.label(egui::RichText::new("Each profile can include:").strong());
-            ui.label("  • Custom shell command and arguments");
-            ui.label("  • Working directory");
-            ui.label("  • Environment variables");
-            ui.label("  • Visual icon for easy identification");
-            ui.label("  • Per-profile badge text override");
-
-            ui.add_space(12.0);
-
-            // Button to open profile manager
-            ui.horizontal(|ui| {
-                if ui
-                    .button("Open Profile Manager")
-                    .on_hover_text(
-                        "Open the profile management window to create, edit, and delete profiles",
-                    )
-                    .clicked()
-                {
-                    settings.open_profile_manager_requested = true;
+            // Handle returned actions
+            match action {
+                ProfileModalAction::Save => {
+                    settings.profile_save_requested = true;
                 }
-
-                ui.label(
-                    egui::RichText::new(
-                        "or use the profile drawer on the right side of the terminal",
-                    )
-                    .small()
-                    .color(egui::Color32::GRAY),
-                );
-            });
-
-            ui.add_space(8.0);
-
-            ui.label(
-                egui::RichText::new(
-                    "Tip: Double-click a profile in the drawer to open it in a new tab",
-                )
-                .small()
-                .color(egui::Color32::GRAY),
-            );
-        },
-    );
-}
-
-// ============================================================================
-// Features Section
-// ============================================================================
-
-fn show_features_section(ui: &mut egui::Ui, collapsed: &mut HashSet<String>) {
-    collapsing_section(
-        ui,
-        "Profile Features",
-        "profiles_features",
-        true,
-        collapsed,
-        |ui| {
-            ui.label(egui::RichText::new("Tags").strong());
-            ui.label("Add searchable tags to organize your profiles. Filter profiles in the drawer by typing tag names.");
-            ui.add_space(8.0);
-
-            ui.label(egui::RichText::new("Profile Inheritance").strong());
-            ui.label("Create a parent profile with base settings, then override specific values in child profiles. Great for sharing common configurations.");
-            ui.add_space(8.0);
-
-            ui.label(egui::RichText::new("Keyboard Shortcuts").strong());
-            ui.label("Assign a keyboard shortcut to quickly launch a profile. Use combinations like Ctrl+Shift+1.");
-            ui.add_space(8.0);
-
-            ui.label(egui::RichText::new("Automatic Profile Switching").strong());
-            ui.label("Configure hostname patterns to automatically switch profiles when connecting to specific servers via SSH. Uses glob patterns like \"*.prod.example.com\".");
-            ui.add_space(8.0);
-
-            ui.label(egui::RichText::new("Tmux Session Auto-Switching").strong());
-            ui.label("Configure tmux session name patterns to automatically apply profiles when connecting via tmux control mode. Uses glob patterns like \"work-*\" or \"*-production\".");
-            ui.add_space(8.0);
-
-            ui.label(egui::RichText::new("Per-Profile Badge").strong());
-            ui.label("Override the global badge format for specific profiles. Useful for displaying different info for production vs development servers.");
+                ProfileModalAction::OpenProfile(id) => {
+                    settings.profile_open_requested = Some(id);
+                }
+                ProfileModalAction::Cancel | ProfileModalAction::None => {}
+            }
         },
     );
 }


### PR DESCRIPTION
## Summary
- Moves profile create/edit/delete/reorder UI from a modal dialog in the terminal window to inline in the Settings > Profiles tab (#125)
- Profile drawer "Manage" button and menu "Manage Profiles" now open the settings window to the Profiles tab
- Removes the `ProfileModalUI` from `WindowState` entirely; all profile management is now consolidated in the settings window

## Test plan
- [x] All 422+ tests pass including 73 profile UI tests
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] `cargo fmt -- --check` passes clean
- [x] Release build succeeds
- [ ] Manual: Open Settings > Profiles tab — profile list renders inline
- [ ] Manual: Create, edit, delete, reorder profiles within Settings
- [ ] Manual: Profile drawer "Manage" button opens Settings to Profiles tab
- [ ] Manual: Menu "Manage Profiles" opens Settings to Profiles tab

Closes #125