### PR TITLE
feat(window): open window in specific macOS Space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Settings UI controls in Appearance > Auto Dark Mode section
   - Defaults: light theme = "Light Background", dark theme = "Dark Background"
 
+- **macOS Target Space**: Open windows in a specific macOS Space (virtual desktop) (#140)
+  - New config option: `target_space` (1-16, or null for OS default)
+  - Uses private SkyLight Server (SLS) APIs with version-aware implementation
+  - Supports both legacy API (macOS < 14.5) and modern compat ID API (macOS 14.5+)
+  - Settings UI control in Window > Window Behavior section (macOS only)
+  - Graceful degradation: logs warning and continues if Space APIs unavailable
+
 ---
 
 ## [0.16.0] - 2026-02-13

--- a/docs/plans/2026-02-13-macos-target-space-design.md
+++ b/docs/plans/2026-02-13-macos-target-space-design.md
@@ -1,0 +1,86 @@
+# macOS Target Space Design
+
+**Issue**: #140 — feat: open window in specific macOS Space
+**Date**: 2026-02-13
+
+## Summary
+
+Add a config option to specify which macOS Space (virtual desktop) a window opens in. Uses private SkyLight Server (SLS) APIs via `dlopen`/`dlsym`, following the same pattern as `macos_blur.rs`.
+
+## Config
+
+```yaml
+target_space: null  # null = OS decides, 1-16 = specific Space number
+```
+
+Field: `pub target_space: Option<u32>` with `#[serde(default)]`
+
+## Architecture
+
+### New File: `src/macos_space.rs`
+
+Follows `macos_blur.rs` pattern:
+- Inner module gated behind `#[cfg(target_os = "macos")]`
+- Public `move_window_to_space(window, space_number)` with no-op on non-macOS
+- Loads SLS functions via `dlopen`/`dlsym` with `OnceLock` caching
+- Version-aware: detects macOS version at runtime
+
+### SLS API Strategy
+
+**macOS < 14.5** (legacy):
+```
+SLSMoveWindowsToManagedSpace(cid, window_list_cfarray, space_id)
+```
+
+**macOS 14.5+** (compat ID workaround):
+```
+SLSSpaceSetCompatID(cid, space_id, COMPAT_MAGIC)
+SLSSetWindowListWorkspace(cid, &window_number, 1, COMPAT_MAGIC)
+SLSSpaceSetCompatID(cid, space_id, 0)  // clear
+```
+
+### Supporting APIs
+
+- `SLSMainConnectionID()` — get CGS connection
+- `SLSGetSpaceManagementMode(cid, space_id)` — verify space exists
+- `NSProcessInfo.operatingSystemVersion` — version detection
+- `NSWindow.windowNumber` — get CGWindowID from winit window
+
+### Integration Point
+
+Called in `WindowManager::apply_window_positioning()` after monitor/edge positioning:
+```rust
+#[cfg(target_os = "macos")]
+if let Some(space) = self.config.target_space {
+    if let Err(e) = crate::macos_space::move_window_to_space(window, space) {
+        log::warn!("Failed to move window to Space {}: {}", space, e);
+    }
+}
+```
+
+## Settings UI
+
+Added to `window_tab.rs` below "Target monitor", same Auto checkbox + slider pattern:
+- Auto checkbox (None = let OS decide)
+- Slider 1-16 when not auto
+- Only visible on macOS (`cfg!(target_os = "macos")`)
+- Note: "Takes effect on next window creation"
+
+## Sidebar Keywords
+
+Add to Window tab: "space", "spaces", "mission control", "virtual desktop", "macos space"
+
+## Error Handling
+
+- SLS functions not found → log warning, skip silently
+- Target Space doesn't exist → log warning, window stays on current Space
+- All errors via `anyhow::Result`
+
+## Files Changed
+
+1. `src/macos_space.rs` — new file, SLS API wrapper
+2. `src/config/mod.rs` — add `target_space: Option<u32>`
+3. `src/app/window_manager.rs` — call `move_window_to_space()` in positioning
+4. `src/settings_ui/window_tab.rs` — add UI control
+5. `src/settings_ui/sidebar.rs` — add search keywords
+6. `src/main.rs` or `src/lib.rs` — register `mod macos_space`

--- a/docs/research/macos-space-apis-2026-02-13.md
+++ b/docs/research/macos-space-apis-2026-02-13.md
@@ -1,0 +1,835 @@
+# macOS Private APIs for Space (Virtual Desktop) Management
+
+**Research Date**: 2026-02-13
+**Last Updated**: 2026-02-13
+**Target Platform**: macOS (Sonoma 14.5+, Sequoia 15.x)
+**Primary Sources**: Yabai, Hammerspoon, CGSInternal
+
+## Overview
+
+This document provides comprehensive technical information on macOS private APIs for managing Spaces (virtual desktops/Mission Control). These APIs enable programmatic control over window placement across different Spaces, which is critical for terminal emulators, window managers, and productivity tools.
+
+**Key Takeaway**: Apple removed public Space management APIs in macOS 10.7, forcing developers to use private CoreGraphics/SkyLight APIs (SLS/CGS) to achieve Space-aware window management. These private APIs work but carry App Store rejection risks and version compatibility concerns.
+
+## API Evolution
+
+### Historical Context
+
+- **Pre-10.7**: Public APIs existed for Space management
+- **10.7 (Lion)**: Apple made Space APIs private, removing official support
+- **10.14 (Mojave)**: ProcessSerialNumber APIs deprecated
+- **14.5 (Sonoma)**: Major API changes requiring `SLSSpaceSetCompatID` workaround
+- **15.x (Sequoia)**: Current stable APIs continue to work with Sonoma 14.5+ patterns
+
+### Current Status (2026)
+
+The private SLS (SkyLight Server) APIs remain functional on modern macOS but require platform-version-specific handling. macOS 14.5+ introduced breaking changes requiring compatibility ID workarounds.
+
+## Core API Functions
+
+### Connection Management
+
+**`SLSMainConnectionID()`**
+```c
+extern int SLSMainConnectionID(void);
+```
+- Returns the main connection ID to the Window Server
+- Called once at application startup, stored globally
+- Required as first parameter to all SLS functions
+
+### Space Information
+
+**`SLSManagedDisplayGetCurrentSpace()`**
+```c
+extern uint64_t SLSManagedDisplayGetCurrentSpace(int cid, CFStringRef display_uuid);
+```
+- Returns the currently active Space ID for a display
+- `display_uuid`: UUID string from NSScreen (or main display UUID)
+- Returns `uint64_t` Space ID
+
+**`SLSCopyManagedDisplayForSpace()`**
+```c
+extern CFStringRef SLSCopyManagedDisplayForSpace(int cid, uint64_t sid);
+```
+- Returns the UUID of the display containing a Space
+- Caller must release the returned `CFStringRef`
+
+**`SLSCopyManagedDisplaySpaces()`**
+```c
+extern CFArrayRef SLSCopyManagedDisplaySpaces(int cid);
+```
+- Returns array of all Spaces across all displays
+- Structure: Array of display dictionaries with Space arrays
+- Caller must release the returned `CFArrayRef`
+
+**`SLSSpaceGetType()`**
+```c
+extern int SLSSpaceGetType(int cid, uint64_t sid);
+```
+- Returns Space type: 0 = user Space, 4 = fullscreen Space
+- Useful for filtering out fullscreen app Spaces
+
+**`SLSSpaceCopyName()`**
+```c
+extern CFStringRef SLSSpaceCopyName(int cid, uint64_t sid);
+```
+- Returns the user-assigned name for a Space (if set in Mission Control)
+- Caller must release the returned `CFStringRef`
+
+**`SLSGetActiveSpace()`**
+```c
+extern uint64_t SLSGetActiveSpace(int cid);
+```
+- Returns the globally active Space ID
+- Equivalent to current Space on the active display
+
+### Window Management
+
+**`SLSCopyWindowsWithOptionsAndTags()`**
+```c
+extern CFArrayRef SLSCopyWindowsWithOptionsAndTags(
+    int cid,
+    uint32_t owner,
+    CFArrayRef spaces,
+    uint32_t options,
+    uint64_t *set_tags,
+    uint64_t *clear_tags
+);
+```
+- Retrieves window IDs for specific Spaces
+- `owner`: 0 for all windows, or specific connection ID
+- `spaces`: Array of Space IDs to query (or NULL for current Space)
+- `options`: Filtering options (0x2 for on-screen windows)
+- Returns array of `NSNumber` objects containing window IDs
+- Caller must release the returned `CFArrayRef`
+
+**`SLSCopySpacesForWindows()`**
+```c
+extern CFArrayRef SLSCopySpacesForWindows(
+    int cid,
+    int selector,
+    CFArrayRef window_list
+);
+```
+- Returns Space IDs containing the specified windows
+- `selector`: 0x7 (common value, purpose unclear)
+- `window_list`: Array of window IDs to query
+- Returns array of Space ID arrays (one per window)
+
+### Moving Windows Between Spaces
+
+#### Modern API (macOS 14.5+, Sequoia)
+
+**`SLSSpaceSetCompatID()` + `SLSSetWindowListWorkspace()`**
+
+Since macOS Sonoma 14.5, the old `SLSMoveWindowsToManagedSpace` requires a compatibility ID workaround:
+
+```c
+extern CGError SLSSpaceSetCompatID(int cid, uint64_t sid, int workspace);
+extern CGError SLSSetWindowListWorkspace(int cid, uint32_t *window_list, int window_count, int workspace);
+```
+
+**Usage Pattern (from Hammerspoon)**:
+```c
+// Magic compatibility ID (ASCII 'yabe' - used by yabai)
+const int COMPAT_ID = 0x79616265;
+
+// Temporary compatibility ID assignment
+SLSSpaceSetCompatID(g_connection, target_space_id, COMPAT_ID);
+
+// Move window(s) to the compatibility workspace
+uint32_t window_id = 12345;
+SLSSetWindowListWorkspace(g_connection, &window_id, 1, COMPAT_ID);
+
+// Clear compatibility ID
+SLSSpaceSetCompatID(g_connection, target_space_id, 0x0);
+```
+
+**Why This Works**:
+- macOS 14.5+ requires explicit workspace ID matching
+- The compatibility ID (`0x79616265` = "yabe") acts as a temporary marker
+- This three-step dance bypasses the new Space isolation checks
+
+#### Legacy API (macOS < 14.5)
+
+**`SLSMoveWindowsToManagedSpace()`**
+```c
+extern void SLSMoveWindowsToManagedSpace(int cid, CFArrayRef window_list, uint64_t sid);
+```
+- `window_list`: CFArray of NSNumber objects (window IDs)
+- `sid`: Target Space ID
+- No return value (void)
+
+**Example**:
+```c
+uint32_t window_id = 12345;
+NSArray *windows = @[@(window_id)];
+SLSMoveWindowsToManagedSpace(g_connection, (__bridge CFArrayRef)windows, target_space_id);
+```
+
+#### Platform-Agnostic Implementation
+
+```c
+void move_window_to_space(int cid, uint32_t wid, uint64_t sid) {
+    if (is_macos_14_5_or_newer()) {
+        // Modern approach
+        SLSSpaceSetCompatID(cid, sid, 0x79616265);
+        SLSSetWindowListWorkspace(cid, &wid, 1, 0x79616265);
+        SLSSpaceSetCompatID(cid, sid, 0x0);
+    } else {
+        // Legacy approach
+        NSArray *windows = @[@(wid)];
+        SLSMoveWindowsToManagedSpace(cid, (__bridge CFArrayRef)windows, sid);
+    }
+}
+```
+
+### Process-Level Space Assignment
+
+**`SLSProcessAssignToSpace()`**
+```c
+extern CGError SLSProcessAssignToSpace(int cid, pid_t pid, uint64_t sid);
+```
+- Assigns a process to a specific Space
+- New windows from that process will open on the assigned Space
+
+**`SLSProcessAssignToAllSpaces()`**
+```c
+extern CGError SLSProcessAssignToAllSpaces(int cid, pid_t pid);
+```
+- Makes process windows appear on all Spaces
+- Equivalent to "Options → All Desktops" in Dock right-click menu
+
+### Space Visibility
+
+**`SLSShowSpaces()` / `SLSHideSpaces()`**
+```c
+extern void SLSShowSpaces(int cid, CFArrayRef space_list);
+extern void SLSHideSpaces(int cid, CFArrayRef space_list);
+```
+- Controls Space visibility in Mission Control
+- `space_list`: Array of Space IDs
+- Used for programmatic Space hiding/showing
+
+### Window Positioning
+
+**`SLSGetWindowBounds()`**
+```c
+extern CGError SLSGetWindowBounds(int cid, uint32_t wid, CGRect *frame);
+```
+- Retrieves window frame in screen coordinates
+
+**`SLSMoveWindow()`**
+```c
+extern CGError SLSMoveWindow(int cid, uint32_t wid, CGPoint *point);
+```
+- Moves window to specified screen coordinates
+
+**`SLSOrderWindow()`**
+```c
+extern CGError SLSOrderWindow(int cid, uint32_t wid, int mode, uint32_t rel_wid);
+```
+- Changes window Z-order
+- `mode`: -1 (below), 0 (out/remove), 1 (above)
+- `rel_wid`: Reference window ID (or 0 for absolute ordering)
+
+## Type Definitions
+
+```c
+// Connection to Window Server
+typedef int CGSConnectionID;
+
+// Window identifier
+typedef uint32_t CGSWindowID;
+
+// Space identifier (64-bit on modern macOS)
+typedef uint64_t CGSSpaceID;
+
+// Display UUID
+typedef CFStringRef CGSDisplayUUID;
+
+// Standard CoreGraphics error type
+typedef int32_t CGError;
+```
+
+## Rust FFI Implementation
+
+### Using objc2 and Core Foundation
+
+The `objc2` crate provides CoreGraphics bindings but does **not** include SLS private APIs. You must declare them manually.
+
+```rust
+use core_foundation::{
+    array::{CFArray, CFArrayRef},
+    base::{CFType, TCFType},
+    number::CFNumber,
+    string::{CFString, CFStringRef},
+};
+use core_graphics::geometry::{CGPoint, CGRect};
+
+// Link against CoreGraphics framework (contains SLS)
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    // Connection
+    fn SLSMainConnectionID() -> i32;
+
+    // Space queries
+    fn SLSManagedDisplayGetCurrentSpace(cid: i32, display_uuid: CFStringRef) -> u64;
+    fn SLSCopyManagedDisplayForSpace(cid: i32, sid: u64) -> CFStringRef;
+    fn SLSCopyManagedDisplaySpaces(cid: i32) -> CFArrayRef;
+    fn SLSSpaceGetType(cid: i32, sid: u64) -> i32;
+    fn SLSGetActiveSpace(cid: i32) -> u64;
+
+    // Window queries
+    fn SLSCopyWindowsWithOptionsAndTags(
+        cid: i32,
+        owner: u32,
+        spaces: CFArrayRef,
+        options: u32,
+        set_tags: *mut u64,
+        clear_tags: *mut u64,
+    ) -> CFArrayRef;
+
+    fn SLSCopySpacesForWindows(
+        cid: i32,
+        selector: i32,
+        window_list: CFArrayRef,
+    ) -> CFArrayRef;
+
+    // Window movement (legacy)
+    fn SLSMoveWindowsToManagedSpace(cid: i32, window_list: CFArrayRef, sid: u64);
+
+    // Window movement (modern)
+    fn SLSSpaceSetCompatID(cid: i32, sid: u64, workspace: i32) -> i32;
+    fn SLSSetWindowListWorkspace(cid: i32, window_list: *mut u32, count: i32, workspace: i32) -> i32;
+
+    // Process assignment
+    fn SLSProcessAssignToSpace(cid: i32, pid: i32, sid: u64) -> i32;
+    fn SLSProcessAssignToAllSpaces(cid: i32, pid: i32) -> i32;
+}
+
+/// Get the Window Server connection ID
+pub fn get_connection_id() -> i32 {
+    unsafe { SLSMainConnectionID() }
+}
+
+/// Get current Space ID for main display
+pub fn get_current_space(cid: i32) -> Option<u64> {
+    unsafe {
+        // Use main display UUID (CGDirectMainDisplay's UUID)
+        // For simplicity, pass NULL to get current active space
+        let sid = SLSGetActiveSpace(cid);
+        if sid > 0 {
+            Some(sid)
+        } else {
+            None
+        }
+    }
+}
+
+/// Move a window to a target Space (modern API)
+pub fn move_window_to_space_modern(cid: i32, window_id: u32, space_id: u64) -> Result<(), i32> {
+    unsafe {
+        const COMPAT_ID: i32 = 0x79616265; // 'yabe'
+
+        // Step 1: Set compatibility ID
+        let err = SLSSpaceSetCompatID(cid, space_id, COMPAT_ID);
+        if err != 0 {
+            return Err(err);
+        }
+
+        // Step 2: Move window
+        let mut wid = window_id;
+        let err = SLSSetWindowListWorkspace(cid, &mut wid, 1, COMPAT_ID);
+        if err != 0 {
+            SLSSpaceSetCompatID(cid, space_id, 0); // Cleanup
+            return Err(err);
+        }
+
+        // Step 3: Clear compatibility ID
+        SLSSpaceSetCompatID(cid, space_id, 0);
+
+        Ok(())
+    }
+}
+
+/// Move a window to a target Space (legacy API)
+pub fn move_window_to_space_legacy(cid: i32, window_id: u32, space_id: u64) {
+    unsafe {
+        let num = CFNumber::from(window_id as i64);
+        let array = CFArray::from_CFTypes(&[num.as_CFType()]);
+        SLSMoveWindowsToManagedSpace(cid, array.as_concrete_TypeRef(), space_id);
+    }
+}
+
+/// Platform-agnostic window movement
+pub fn move_window_to_space(cid: i32, window_id: u32, space_id: u64) -> Result<(), i32> {
+    // Check macOS version (implement version detection)
+    let is_14_5_or_newer = check_macos_version_14_5_or_newer();
+
+    if is_14_5_or_newer {
+        move_window_to_space_modern(cid, window_id, space_id)
+    } else {
+        move_window_to_space_legacy(cid, window_id, space_id);
+        Ok(())
+    }
+}
+
+/// Helper: Check if macOS 14.5+
+fn check_macos_version_14_5_or_newer() -> bool {
+    use std::process::Command;
+
+    if let Ok(output) = Command::new("sw_vers").arg("-productVersion").output() {
+        if let Ok(version_str) = String::from_utf8(output.stdout) {
+            // Parse version string "14.5.0" -> (14, 5, 0)
+            let parts: Vec<&str> = version_str.trim().split('.').collect();
+            if let (Some(major), Some(minor)) = (parts.get(0), parts.get(1)) {
+                if let (Ok(maj), Ok(min)) = (major.parse::<u32>(), minor.parse::<u32>()) {
+                    return maj > 14 || (maj == 14 && min >= 5);
+                }
+            }
+        }
+    }
+
+    // Default to modern API on unknown version
+    true
+}
+```
+
+### Getting Window IDs
+
+To move windows, you need their window IDs. Use the Accessibility API or NSWindow methods:
+
+```rust
+use cocoa::appkit::NSWindow;
+use cocoa::base::id;
+use objc::{msg_send, sel, sel_impl};
+
+/// Get window ID from NSWindow
+pub fn get_window_id(ns_window: id) -> u32 {
+    unsafe {
+        let window_number: i32 = msg_send![ns_window, windowNumber];
+        window_number as u32
+    }
+}
+```
+
+## Alternative Public API Approaches
+
+### NSWindow.collectionBehavior
+
+`NSWindow.CollectionBehavior.moveToActiveSpace` is a **public API** from macOS 10.5+:
+
+```swift
+window.collectionBehavior.insert(.moveToActiveSpace)
+```
+
+**Behavior**: When the window becomes active (user clicks it), macOS automatically moves it to the current Space instead of switching Spaces.
+
+**Limitations**:
+- Only works when window is activated by user
+- Cannot programmatically move windows to specific Spaces
+- Does not provide Space queries or multi-Space control
+
+**Rust Equivalent**:
+```rust
+use cocoa::appkit::{NSWindow, NSWindowCollectionBehavior};
+use cocoa::base::id;
+use objc::{msg_send, sel, sel_impl};
+
+pub fn set_move_to_active_space(window: id) {
+    unsafe {
+        let behavior: NSWindowCollectionBehavior = msg_send![window, collectionBehavior];
+        let new_behavior = behavior | NSWindowCollectionBehavior::NSWindowCollectionBehaviorMoveToActiveSpace;
+        let _: () = msg_send![window, setCollectionBehavior: new_behavior];
+    }
+}
+```
+
+### CGEvent-Based Workaround (App Store Safe)
+
+From the article [Accessibility, Windows, and Spaces in OS X](https://ianyh.com/blog/accessibility-windows-and-spaces-in-os-x/), an App Store-compatible approach uses synthetic events:
+
+**Concept**: Simulate user actions (mouse grab + Control+Arrow keys) to move windows.
+
+**Advantages**:
+- No private APIs (App Store safe)
+- Works across macOS versions
+
+**Disadvantages**:
+- Requires Accessibility permissions
+- Visually intrusive (brief cursor movement, Space animation)
+- Unreliable with some applications (e.g., Xcode)
+- Slow (~500ms for animation)
+
+**Implementation Summary**:
+1. Move cursor to window's title bar (near green zoom button)
+2. Post mouse-down event to "grab" window
+3. Post Control+Arrow keyboard events to switch Space (window follows)
+4. Post mouse-up event to release window
+
+This approach is suitable for user-facing tools but not ideal for background automation or terminal emulators.
+
+## How Terminal Emulators Handle Spaces
+
+### Alacritty
+- **No native Space management**: Relies on external tools like Hammerspoon
+- Users configure Hammerspoon scripts to move Alacritty windows to specific Spaces
+- Example: [Guake-style terminal with Alacritty + Hammerspoon](https://world.hey.com/jonash/alacritty-drop-down-guake-quake-style-terminal-setup-on-macos-6eef7d73)
+
+### Kitty
+- **No documented Space API usage**
+- Focuses on standard NSWindow behaviors
+- Users rely on macOS window management or third-party tools
+
+### iTerm2
+- **No public Space management features**
+- May use private APIs internally (closed source, unconfirmed)
+- Users typically use Hammerspoon or Aerospace for advanced Space control
+
+### Ghostty
+- **SwiftUI + Native macOS Integration**: Ghostty is a native Swift app with full macOS windowing support
+- **No apparent Space API usage**: GitHub discussions show users pairing Ghostty with Aerospace window manager
+- **Related Issues**:
+  - [Quick Terminal not visible in all Aerospace workspaces](https://github.com/ghostty-org/ghostty/discussions/3512)
+  - [Multi-monitor window placement issues](https://github.com/ghostty-org/ghostty/discussions/8673)
+- **Architecture**: Main entry point is Swift, links to `libghostty` (likely Zig/C++) for terminal emulation
+- **Takeaway**: Even modern native terminals don't implement custom Space management—they rely on external window managers
+
+### Common Pattern
+**Terminal emulators avoid implementing Space management directly**. Instead:
+- Provide standard NSWindow behaviors
+- Let users configure external tools (Hammerspoon, Aerospace, Yabai)
+- Focus on terminal emulation, not window management
+
+## Third-Party Window Managers
+
+### Yabai
+- **C implementation** using SLS private APIs
+- Full source available: [koekeishiya/yabai](https://github.com/koekeishiya/yabai)
+- Requires partial SIP disable for full functionality
+- Uses `SLSMoveWindowsToManagedSpace` (pre-14.5) and compatibility ID workaround (14.5+)
+- Primary reference: [`src/misc/extern.h`](https://github.com/asmvik/yabai/blob/master/src/misc/extern.h)
+
+### Hammerspoon
+- **Lua-scriptable macOS automation**
+- `hs.spaces` module wraps SLS APIs
+- Full source: [Hammerspoon/hammerspoon](https://github.com/Hammerspoon/hammerspoon)
+- Reference implementation: [`extensions/spaces/libspaces.m`](https://github.com/Hammerspoon/hammerspoon/blob/master/extensions/spaces/libspaces.m)
+- **Sequoia compatibility**: [Issue #3698](https://github.com/Hammerspoon/hammerspoon/issues/3698) shows macOS 15.0 initially broke `moveWindowToSpace`, later fixed
+
+### Aerospace
+- **Rust-based** tiling window manager inspired by i3
+- Uses SLS APIs (source not directly linked in search results)
+- Actively maintained for modern macOS
+- Ghostty users commonly pair Aerospace for workspace management
+
+## Risks and Limitations
+
+### App Store Rejection
+**Risk Level**: **HIGH**
+
+Using private APIs (SLS/CGS) will result in **automatic rejection** from the Mac App Store. Apple scans for private API usage during review.
+
+**Workarounds**:
+- Distribute outside App Store (direct download, Homebrew)
+- Use CGEvent-based workaround (slow, requires Accessibility permissions)
+- Use `NSWindow.collectionBehavior.moveToActiveSpace` (limited functionality)
+
+### API Stability
+**Risk Level**: **MEDIUM**
+
+Private APIs can change without notice:
+- **macOS 14.5 (Sonoma)**: Broke `SLSMoveWindowsToManagedSpace`, required compatibility ID workaround
+- **macOS 15.0 (Sequoia)**: Initially broke Hammerspoon's `moveWindowToSpace`, later stabilized
+- **Future versions**: No guarantees of continued compatibility
+
+**Mitigation**:
+- Implement platform version detection
+- Provide fallback behaviors
+- Monitor window manager projects (Yabai, Hammerspoon) for compatibility updates
+- Abstract SLS calls behind a compatibility layer
+
+### System Integrity Protection (SIP)
+**Risk Level**: **MEDIUM**
+
+Some Space operations (e.g., Yabai's scripting addition injection into Dock.app) require **partial SIP disable**. Moving windows to Spaces does **not** require SIP changes—only reading/writing Space metadata requires elevated access.
+
+**SIP-Free Operations**:
+- `SLSMoveWindowsToManagedSpace` (and modern equivalents)
+- `SLSProcessAssignToSpace`
+- `SLSGetActiveSpace`
+- Window queries
+
+**SIP-Protected Operations**:
+- Injecting code into Dock.app
+- Modifying Space creation/deletion
+- Advanced Space reordering
+
+### Process Permissions
+**Risk Level**: **LOW**
+
+No special entitlements needed for basic Space operations. Accessibility permissions are **not** required for SLS APIs (unlike the CGEvent workaround).
+
+### Deprecation of ProcessSerialNumber
+**Risk Level**: **LOW** (No longer relevant)
+
+Legacy function `CGSGetConnectionIDForPSN()` used `ProcessSerialNumber`, which is deprecated. Modern code uses `SLSMainConnectionID()` (no PSN needed) or process IDs (PIDs).
+
+## macOS Version Compatibility Matrix
+
+| macOS Version | `SLSMoveWindowsToManagedSpace` | Modern API (CompatID) | Notes |
+|---------------|--------------------------------|-----------------------|-------|
+| 10.13-14.4 | ✅ Works | ❌ Not needed | Use legacy API directly |
+| 14.5-14.x | ⚠️ Requires workaround | ✅ Required | Must use 3-step CompatID pattern |
+| 15.x (Sequoia) | ⚠️ Requires workaround | ✅ Required | Same as Sonoma 14.5+ |
+| Future | ❓ Unknown | ❓ Unknown | Monitor Yabai/Hammerspoon for updates |
+
+## Best Practices
+
+### For Terminal Emulators
+
+1. **Don't implement Space management unless absolutely necessary**
+   - Most users prefer external window managers (Aerospace, Yabai, Hammerspoon)
+   - Focus on terminal emulation quality
+
+2. **If implementing, use a compatibility layer**
+   - Abstract SLS APIs behind a versioned abstraction
+   - Gracefully degrade on API failures
+   - Provide user-facing errors when Space operations fail
+
+3. **Expose public APIs where possible**
+   - Allow users to set `NSWindow.collectionBehavior` via config
+   - Document integration with external window managers
+   - Provide window management hooks for scripting (if supported)
+
+4. **Consider distribution model**
+   - If targeting App Store: **Do not use SLS APIs**
+   - If distributing via Homebrew/direct: Private APIs are viable
+
+### For Development
+
+1. **Version Detection is Critical**
+   ```rust
+   fn check_macos_version_14_5_or_newer() -> bool {
+       // Parse sw_vers output or use NSProcessInfo
+   }
+   ```
+
+2. **Handle Errors Gracefully**
+   ```rust
+   match move_window_to_space(cid, wid, sid) {
+       Ok(_) => println!("Window moved successfully"),
+       Err(e) => eprintln!("Failed to move window: CGError {}", e),
+   }
+   ```
+
+3. **Test Across macOS Versions**
+   - Use VMs or physical hardware for testing
+   - Monitor Hammerspoon/Yabai issue trackers for breakage reports
+
+4. **Abstract SLS APIs**
+   ```rust
+   trait SpaceManager {
+       fn move_window_to_space(&self, window_id: u32, space_id: u64) -> Result<(), String>;
+   }
+
+   struct SLSSpaceManager { cid: i32 }
+   struct NoOpSpaceManager; // Fallback for non-macOS
+   ```
+
+## Debugging and Testing
+
+### Logging SLS Calls
+
+Enable CoreGraphics debug logging:
+```bash
+defaults write -g CGDebugOptions -int 16
+# Restart application
+```
+
+### Inspecting Spaces
+
+Use Hammerspoon console:
+```lua
+hs.spaces.allSpaces()  -- List all Spaces
+hs.spaces.activeSpaces()  -- Currently active Spaces per display
+hs.spaces.windowsForSpace(space_id)  -- Windows on a Space
+```
+
+### Verifying Window Movement
+
+Check Space ownership after moving:
+```rust
+let spaces = SLSCopySpacesForWindows(cid, 0x7, window_array);
+// Parse returned CFArray to verify window is on target Space
+```
+
+## Complete Example: Moving par-term Window to Specific Space
+
+```rust
+#[cfg(target_os = "macos")]
+mod macos_spaces {
+    use core_foundation::array::{CFArray, CFArrayRef};
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::number::CFNumber;
+    use core_foundation::string::CFStringRef;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn SLSMainConnectionID() -> i32;
+        fn SLSGetActiveSpace(cid: i32) -> u64;
+        fn SLSSpaceSetCompatID(cid: i32, sid: u64, workspace: i32) -> i32;
+        fn SLSSetWindowListWorkspace(cid: i32, window_list: *mut u32, count: i32, workspace: i32) -> i32;
+        fn SLSMoveWindowsToManagedSpace(cid: i32, window_list: CFArrayRef, sid: u64);
+    }
+
+    pub struct SpaceManager {
+        connection_id: i32,
+    }
+
+    impl SpaceManager {
+        pub fn new() -> Self {
+            Self {
+                connection_id: unsafe { SLSMainConnectionID() },
+            }
+        }
+
+        pub fn current_space(&self) -> u64 {
+            unsafe { SLSGetActiveSpace(self.connection_id) }
+        }
+
+        pub fn move_window_to_space(&self, window_id: u32, space_id: u64) -> Result<(), i32> {
+            if Self::is_macos_14_5_or_newer() {
+                self.move_window_modern(window_id, space_id)
+            } else {
+                self.move_window_legacy(window_id, space_id);
+                Ok(())
+            }
+        }
+
+        fn move_window_modern(&self, window_id: u32, space_id: u64) -> Result<(), i32> {
+            unsafe {
+                const COMPAT_ID: i32 = 0x79616265;
+
+                let err = SLSSpaceSetCompatID(self.connection_id, space_id, COMPAT_ID);
+                if err != 0 {
+                    return Err(err);
+                }
+
+                let mut wid = window_id;
+                let err = SLSSetWindowListWorkspace(self.connection_id, &mut wid, 1, COMPAT_ID);
+                if err != 0 {
+                    SLSSpaceSetCompatID(self.connection_id, space_id, 0);
+                    return Err(err);
+                }
+
+                SLSSpaceSetCompatID(self.connection_id, space_id, 0);
+                Ok(())
+            }
+        }
+
+        fn move_window_legacy(&self, window_id: u32, space_id: u64) {
+            unsafe {
+                let num = CFNumber::from(window_id as i64);
+                let array = CFArray::from_CFTypes(&[num.as_CFType()]);
+                SLSMoveWindowsToManagedSpace(
+                    self.connection_id,
+                    array.as_concrete_TypeRef(),
+                    space_id
+                );
+            }
+        }
+
+        fn is_macos_14_5_or_newer() -> bool {
+            use std::process::Command;
+
+            if let Ok(output) = Command::new("sw_vers").arg("-productVersion").output() {
+                if let Ok(version_str) = String::from_utf8(output.stdout) {
+                    let parts: Vec<&str> = version_str.trim().split('.').collect();
+                    if let (Some(major), Some(minor)) = (parts.get(0), parts.get(1)) {
+                        if let (Ok(maj), Ok(min)) = (major.parse::<u32>(), minor.parse::<u32>()) {
+                            return maj > 14 || (maj == 14 && min >= 5);
+                        }
+                    }
+                }
+            }
+
+            true // Default to modern API
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn example_usage() {
+    use cocoa::appkit::NSWindow;
+    use cocoa::base::id;
+    use objc::{msg_send, sel, sel_impl};
+
+    // Get window ID from winit or NSWindow
+    let ns_window: id = /* your NSWindow */;
+    let window_number: i32 = unsafe { msg_send![ns_window, windowNumber] };
+    let window_id = window_number as u32;
+
+    // Initialize Space manager
+    let manager = macos_spaces::SpaceManager::new();
+
+    // Get target Space ID (example: Space 3)
+    let target_space_id = 3; // Replace with actual Space ID query
+
+    // Move window
+    match manager.move_window_to_space(window_id, target_space_id) {
+        Ok(_) => println!("Successfully moved window to Space {}", target_space_id),
+        Err(e) => eprintln!("Failed to move window: CGError {}", e),
+    }
+}
+```
+
+## Sources
+
+### Primary API Documentation
+- [CGSInternal/CGSConnection.h](https://github.com/NUIKit/CGSInternal/blob/master/CGSConnection.h) - Comprehensive CGS API header collection
+- [yabai/src/misc/extern.h](https://github.com/asmvik/yabai/blob/master/src/misc/extern.h) - Complete SLS function declarations
+- [Hammerspoon/libspaces.m](https://github.com/Hammerspoon/hammerspoon/blob/master/extensions/spaces/libspaces.m) - Reference implementation with macOS 14.5+ workarounds
+
+### Implementation Examples
+- [Yabai GitHub Repository](https://github.com/koekeishiya/yabai) - Full-featured window manager using SLS APIs
+- [Hammerspoon GitHub Repository](https://github.com/Hammerspoon/hammerspoon) - Lua-scriptable automation with `hs.spaces` module
+- [hs._asm.undocumented.spaces](https://github.com/asmagill/hs._asm.undocumented.spaces) - Legacy Hammerspoon Spaces module
+
+### Articles and Discussions
+- [Accessibility, Windows, and Spaces in OS X](https://ianyh.com/blog/accessibility-windows-and-spaces-in-os-x/) - CGEvent-based workaround (App Store safe)
+- [Move your application windows between spaces](https://tonyarnold.com/2008/12/05/move-your-application-windows-between-spaces.html) - Historical CGSMoveWorkspaceWindowList usage
+- [Getting started with making macOS utility app using private APIs](https://speakerdeck.com/niw/getting-started-with-making-macos-utility-app-using-private-apis) - Overview of private API development
+- [Exploring macOS private frameworks](https://www.jviotti.com/2023/11/20/exploring-macos-private-frameworks.html) - Deep dive into macOS private frameworks
+
+### Terminal Emulator Research
+- [Ghostty GitHub Repository](https://github.com/ghostty-org/ghostty) - Modern native Swift/Metal terminal emulator
+- [Alacritty Drop-down setup on macOS](https://world.hey.com/jonash/alacritty-drop-down-guake-quake-style-terminal-setup-on-macos-6eef7d73) - Using Hammerspoon for Space management
+- [Ghostty Discussion #3512](https://github.com/ghostty-org/ghostty/discussions/3512) - Quick Terminal and Aerospace workspace integration
+- [Hammerspoon Issue #3698](https://github.com/Hammerspoon/hammerspoon/issues/3698) - macOS 15.0 Sequoia compatibility fixes
+
+### Apple Documentation
+- [NSWindow.CollectionBehavior](https://developer.apple.com/documentation/appkit/nswindow/collectionbehavior-swift.struct) - Public API for window behaviors
+- [moveToActiveSpace](https://developer.apple.com/documentation/appkit/nswindow/collectionbehavior-swift.struct/movetoactivespace) - Public Space-related behavior
+
+### Rust FFI Resources
+- [FFI - The Rustonomicon](https://doc.rust-lang.org/nomicon/ffi.html) - Official Rust FFI documentation
+- [objc2 GitHub Repository](https://github.com/madsmtm/objc2) - Rust bindings to Apple frameworks
+- [objc2-core-graphics crate](https://crates.io/crates/objc2-core-graphics) - CoreGraphics bindings (no SLS APIs)
+
+## Conclusion
+
+macOS Space management via private SLS APIs is **viable but risky**:
+- ✅ **Functional**: APIs work on modern macOS (Sonoma, Sequoia)
+- ✅ **Well-documented**: Extensive prior art from Yabai, Hammerspoon, and community projects
+- ⚠️ **Version-dependent**: Requires version-specific handling (14.5+ compatibility IDs)
+- ❌ **App Store incompatible**: Automatic rejection for private API usage
+- ⚠️ **Stability concerns**: No guarantees against future breakage
+
+**Recommendation for par-term**:
+- If distributing via Homebrew/direct download: Implement SLS APIs with version abstraction
+- If targeting App Store: Use `NSWindow.collectionBehavior.moveToActiveSpace` only (limited functionality)
+- Consider deferring Space management to external tools (Aerospace, Hammerspoon) and focus on core terminal features
+
+**Rust Implementation Viability**: High—objc2 + manual FFI declarations provide a clean abstraction layer.

--- a/src/app/window_manager.rs
+++ b/src/app/window_manager.rs
@@ -660,6 +660,13 @@ impl WindowManager {
                 }
             }
         }
+
+        // Move window to target macOS Space if configured (macOS only, no-op on other platforms)
+        if let Some(space) = self.config.target_space
+            && let Err(e) = crate::macos_space::move_window_to_space(window, space)
+        {
+            log::warn!("Failed to move window to Space {}: {}", space, e);
+        }
     }
 
     /// Close a specific window

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -286,6 +286,12 @@ pub struct Config {
     #[serde(default)]
     pub target_monitor: Option<usize>,
 
+    /// Target macOS Space (virtual desktop) for window placement (1-based ordinal)
+    /// Use None to let the OS decide which Space to open on.
+    /// Only effective on macOS; ignored on other platforms.
+    #[serde(default)]
+    pub target_space: Option<u32>,
+
     /// Lock window size to prevent resize
     /// When true, the window cannot be resized by the user
     #[serde(default = "defaults::bool_false")]
@@ -1786,6 +1792,7 @@ impl Default for Config {
             window_decorations: defaults::bool_true(),
             window_type: WindowType::default(),
             target_monitor: None,
+            target_space: None,
             lock_window_size: defaults::bool_false(),
             show_window_number: defaults::bool_false(),
             transparency_affects_only_default_background: defaults::bool_true(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod integrations_ui;
 pub mod keybindings;
 pub mod macos_blur; // macOS window blur using private CGS API
 pub mod macos_metal; // macOS-specific CAMetalLayer configuration
+pub mod macos_space; // macOS Space (virtual desktop) targeting using private SLS API
 pub mod manifest;
 pub mod menu;
 pub mod pane;

--- a/src/macos_space.rs
+++ b/src/macos_space.rs
@@ -1,0 +1,397 @@
+//! macOS window Space (virtual desktop) targeting using private SLS APIs
+//!
+//! Uses SkyLight Server (SLS) private APIs to move windows to specific macOS Spaces.
+//! macOS 14.5+ requires a compatibility ID workaround; older versions use the legacy API.
+//!
+//! This follows the same dlopen/dlsym pattern as `macos_blur.rs` for private API access.
+//! CoreFoundation public functions are linked directly since they are always available.
+//!
+//! Note: This only works on macOS. On other platforms, the function is a no-op.
+
+#[cfg(not(target_os = "macos"))]
+use anyhow::Result;
+
+#[cfg(target_os = "macos")]
+mod inner {
+    use anyhow::Result;
+    use objc2_app_kit::NSView;
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use std::ffi::c_void;
+    use std::sync::OnceLock;
+
+    // ========================================================================
+    // CoreFoundation public API declarations (always available on macOS)
+    // ========================================================================
+
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x08000100;
+    const K_CF_NUMBER_SINT64_TYPE: isize = 4;
+    const K_CF_NUMBER_SINT32_TYPE: isize = 3;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn CFArrayGetCount(theArray: *const c_void) -> isize;
+        fn CFArrayGetValueAtIndex(theArray: *const c_void, idx: isize) -> *const c_void;
+        fn CFDictionaryGetValue(theDict: *const c_void, key: *const c_void) -> *const c_void;
+        fn CFNumberGetValue(number: *const c_void, theType: isize, valuePtr: *mut c_void) -> bool;
+        fn CFRelease(cf: *const c_void);
+        fn CFStringCreateWithCString(
+            alloc: *const c_void,
+            cStr: *const i8,
+            encoding: u32,
+        ) -> *const c_void;
+    }
+
+    // ========================================================================
+    // SLS private API function types (loaded via dlsym)
+    // ========================================================================
+
+    type SLSMainConnectionIDFn = unsafe extern "C" fn() -> i32;
+    type SLSCopyManagedDisplaySpacesFn = unsafe extern "C" fn(cid: i32) -> *const c_void;
+    type SLSMoveWindowsToManagedSpaceFn =
+        unsafe extern "C" fn(cid: i32, window_list: *const c_void, sid: u64);
+    type SLSSpaceSetCompatIDFn = unsafe extern "C" fn(cid: i32, sid: u64, workspace: i32) -> i32;
+    type SLSSetWindowListWorkspaceFn =
+        unsafe extern "C" fn(cid: i32, window_list: *mut u32, count: i32, workspace: i32) -> i32;
+
+    // ========================================================================
+    // Cached function pointers
+    // ========================================================================
+
+    struct SlsFunctions {
+        main_connection_id: SLSMainConnectionIDFn,
+        copy_managed_display_spaces: SLSCopyManagedDisplaySpacesFn,
+        move_windows_to_managed_space: SLSMoveWindowsToManagedSpaceFn,
+        space_set_compat_id: SLSSpaceSetCompatIDFn,
+        set_window_list_workspace: SLSSetWindowListWorkspaceFn,
+    }
+
+    static SLS_FNS: OnceLock<Option<SlsFunctions>> = OnceLock::new();
+
+    fn load_sls_functions() -> Option<&'static SlsFunctions> {
+        SLS_FNS
+            .get_or_init(|| unsafe {
+                let handle = libc::dlopen(
+                    c"/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight".as_ptr(),
+                    libc::RTLD_LAZY,
+                );
+                if handle.is_null() {
+                    log::warn!("Failed to open SkyLight framework for Space targeting");
+                    return None;
+                }
+
+                macro_rules! load_sym {
+                    ($name:expr, $ty:ty) => {{
+                        let sym = libc::dlsym(handle, $name.as_ptr());
+                        if sym.is_null() {
+                            log::warn!(
+                                "SLS function {} not found",
+                                String::from_utf8_lossy($name.to_bytes())
+                            );
+                            return None;
+                        }
+                        std::mem::transmute::<*mut c_void, $ty>(sym)
+                    }};
+                }
+
+                Some(SlsFunctions {
+                    main_connection_id: load_sym!(c"SLSMainConnectionID", SLSMainConnectionIDFn),
+                    copy_managed_display_spaces: load_sym!(
+                        c"SLSCopyManagedDisplaySpaces",
+                        SLSCopyManagedDisplaySpacesFn
+                    ),
+                    move_windows_to_managed_space: load_sym!(
+                        c"SLSMoveWindowsToManagedSpace",
+                        SLSMoveWindowsToManagedSpaceFn
+                    ),
+                    space_set_compat_id: load_sym!(c"SLSSpaceSetCompatID", SLSSpaceSetCompatIDFn),
+                    set_window_list_workspace: load_sym!(
+                        c"SLSSetWindowListWorkspace",
+                        SLSSetWindowListWorkspaceFn
+                    ),
+                })
+            })
+            .as_ref()
+    }
+
+    // ========================================================================
+    // macOS version detection
+    // ========================================================================
+
+    static IS_14_5_OR_NEWER: OnceLock<bool> = OnceLock::new();
+
+    fn is_macos_14_5_or_newer() -> bool {
+        *IS_14_5_OR_NEWER.get_or_init(|| {
+            // Use sw_vers to detect macOS version
+            match std::process::Command::new("sw_vers")
+                .arg("-productVersion")
+                .output()
+            {
+                Ok(output) => {
+                    let version_str = String::from_utf8_lossy(&output.stdout);
+                    let parts: Vec<&str> = version_str.trim().split('.').collect();
+                    match (
+                        parts.first().and_then(|s| s.parse::<u32>().ok()),
+                        parts.get(1).and_then(|s| s.parse::<u32>().ok()),
+                    ) {
+                        (Some(major), Some(minor)) => {
+                            log::info!(
+                                "macOS version {} — using {} Space API",
+                                version_str.trim(),
+                                if major > 14 || (major == 14 && minor >= 5) {
+                                    "modern (compat ID)"
+                                } else {
+                                    "legacy"
+                                }
+                            );
+                            major > 14 || (major == 14 && minor >= 5)
+                        }
+                        _ => {
+                            log::warn!("Could not parse macOS version, defaulting to modern API");
+                            true
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::warn!("Failed to run sw_vers: {}, defaulting to modern API", e);
+                    true
+                }
+            }
+        })
+    }
+
+    // ========================================================================
+    // Space enumeration
+    // ========================================================================
+
+    /// Enumerate user Space IDs on the primary display, in Mission Control order.
+    /// Returns Space IDs for type-0 (user) Spaces only (excludes fullscreen Spaces).
+    fn enumerate_user_spaces(sls: &SlsFunctions) -> Vec<u64> {
+        unsafe {
+            let cid = (sls.main_connection_id)();
+            let display_spaces = (sls.copy_managed_display_spaces)(cid);
+            if display_spaces.is_null() {
+                log::warn!("SLSCopyManagedDisplaySpaces returned null");
+                return Vec::new();
+            }
+
+            let mut user_spaces = Vec::new();
+            let display_count = CFArrayGetCount(display_spaces);
+
+            // Iterate over displays (usually just one for primary)
+            for i in 0..display_count {
+                let display_dict = CFArrayGetValueAtIndex(display_spaces, i);
+                if display_dict.is_null() {
+                    continue;
+                }
+
+                // Get the "Spaces" array from the display dictionary
+                let spaces_key = CFStringCreateWithCString(
+                    std::ptr::null(),
+                    c"Spaces".as_ptr(),
+                    K_CF_STRING_ENCODING_UTF8,
+                );
+                if spaces_key.is_null() {
+                    continue;
+                }
+
+                let spaces_array = CFDictionaryGetValue(display_dict, spaces_key);
+                CFRelease(spaces_key);
+                if spaces_array.is_null() {
+                    continue;
+                }
+
+                let space_count = CFArrayGetCount(spaces_array);
+                let id64_key = CFStringCreateWithCString(
+                    std::ptr::null(),
+                    c"id64".as_ptr(),
+                    K_CF_STRING_ENCODING_UTF8,
+                );
+                let type_key = CFStringCreateWithCString(
+                    std::ptr::null(),
+                    c"type".as_ptr(),
+                    K_CF_STRING_ENCODING_UTF8,
+                );
+                if id64_key.is_null() || type_key.is_null() {
+                    if !id64_key.is_null() {
+                        CFRelease(id64_key);
+                    }
+                    if !type_key.is_null() {
+                        CFRelease(type_key);
+                    }
+                    continue;
+                }
+
+                for j in 0..space_count {
+                    let space_dict = CFArrayGetValueAtIndex(spaces_array, j);
+                    if space_dict.is_null() {
+                        continue;
+                    }
+
+                    // Get Space type — 0 = user Space, 4 = fullscreen
+                    let type_num = CFDictionaryGetValue(space_dict, type_key);
+                    if !type_num.is_null() {
+                        let mut space_type: i32 = 0;
+                        CFNumberGetValue(
+                            type_num,
+                            K_CF_NUMBER_SINT32_TYPE,
+                            &mut space_type as *mut i32 as *mut c_void,
+                        );
+                        if space_type != 0 {
+                            continue; // Skip fullscreen Spaces
+                        }
+                    }
+
+                    // Get Space ID (id64)
+                    let id_num = CFDictionaryGetValue(space_dict, id64_key);
+                    if !id_num.is_null() {
+                        let mut space_id: u64 = 0;
+                        if CFNumberGetValue(
+                            id_num,
+                            K_CF_NUMBER_SINT64_TYPE,
+                            &mut space_id as *mut u64 as *mut c_void,
+                        ) {
+                            user_spaces.push(space_id);
+                        }
+                    }
+                }
+
+                CFRelease(id64_key);
+                CFRelease(type_key);
+
+                // Only use the first display's Spaces (primary display)
+                break;
+            }
+
+            CFRelease(display_spaces);
+            user_spaces
+        }
+    }
+
+    // ========================================================================
+    // Window movement
+    // ========================================================================
+
+    /// Move a window to a specific Space using the modern API (macOS 14.5+).
+    fn move_window_modern(
+        sls: &SlsFunctions,
+        cid: i32,
+        window_number: u32,
+        space_id: u64,
+    ) -> Result<()> {
+        unsafe {
+            const COMPAT_ID: i32 = 0x79616265; // 'yabe' — standard marker used by yabai
+
+            // Step 1: Set temporary compatibility ID on the target Space
+            let err = (sls.space_set_compat_id)(cid, space_id, COMPAT_ID);
+            if err != 0 {
+                anyhow::bail!("SLSSpaceSetCompatID failed with error code: {}", err);
+            }
+
+            // Step 2: Move window to the workspace with that compat ID
+            let mut wid = window_number;
+            let err = (sls.set_window_list_workspace)(cid, &mut wid, 1, COMPAT_ID);
+            if err != 0 {
+                // Clean up the compat ID before returning error
+                let _ = (sls.space_set_compat_id)(cid, space_id, 0);
+                anyhow::bail!("SLSSetWindowListWorkspace failed with error code: {}", err);
+            }
+
+            // Step 3: Clear the compatibility ID
+            let _ = (sls.space_set_compat_id)(cid, space_id, 0);
+
+            Ok(())
+        }
+    }
+
+    /// Move a window to a specific Space using the legacy API (macOS < 14.5).
+    fn move_window_legacy(sls: &SlsFunctions, cid: i32, window_number: u32, space_id: u64) {
+        unsafe {
+            // Create a CFArray containing just the window number
+            let num = objc2_foundation::NSNumber::new_i64(window_number as i64);
+            let array = objc2_foundation::NSArray::from_slice(&[&*num]);
+            // NSArray is toll-free bridged with CFArrayRef
+            let cf_array = &*array as *const objc2_foundation::NSArray<objc2_foundation::NSNumber>
+                as *const c_void;
+            (sls.move_windows_to_managed_space)(cid, cf_array, space_id);
+        }
+    }
+
+    /// Move the window to a specific macOS Space (virtual desktop).
+    ///
+    /// # Arguments
+    /// * `window` - The winit window to move
+    /// * `space_number` - 1-based Space ordinal (1 = first Space in Mission Control)
+    ///
+    /// # Notes
+    /// - Uses private macOS SLS APIs that may change between OS versions
+    /// - Gracefully fails if APIs are unavailable or Space doesn't exist
+    pub fn move_window_to_space(window: &winit::window::Window, space_number: u32) -> Result<()> {
+        let sls = load_sls_functions().ok_or_else(|| {
+            anyhow::anyhow!("SLS Space functions not available on this macOS version")
+        })?;
+
+        // Get window number from NSView → NSWindow
+        let window_handle = window.window_handle()?;
+        let ns_view_ptr = match window_handle.as_raw() {
+            RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr(),
+            _ => anyhow::bail!("Not a macOS AppKit window"),
+        };
+
+        let window_number: u32 = unsafe {
+            let ns_view = ns_view_ptr as *mut NSView;
+            let view = &*ns_view;
+            let ns_window: *const objc2::runtime::AnyObject = objc2::msg_send![view, window];
+            if ns_window.is_null() {
+                anyhow::bail!("Failed to get NSWindow from NSView");
+            }
+            let num: i64 = objc2::msg_send![ns_window, windowNumber];
+            num as u32
+        };
+
+        // Enumerate user Spaces to map ordinal → Space ID
+        let user_spaces = enumerate_user_spaces(sls);
+        if user_spaces.is_empty() {
+            anyhow::bail!("No user Spaces found");
+        }
+
+        let index = (space_number as usize).saturating_sub(1); // 1-based to 0-based
+        let space_id = user_spaces.get(index).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Space {} does not exist (found {} Spaces)",
+                space_number,
+                user_spaces.len()
+            )
+        })?;
+
+        let cid = unsafe { (sls.main_connection_id)() };
+
+        log::info!(
+            "Moving window {} to Space {} (internal ID: {}, {} API)",
+            window_number,
+            space_number,
+            space_id,
+            if is_macos_14_5_or_newer() {
+                "modern"
+            } else {
+                "legacy"
+            }
+        );
+
+        if is_macos_14_5_or_newer() {
+            move_window_modern(sls, cid, window_number, *space_id)?;
+        } else {
+            move_window_legacy(sls, cid, window_number, *space_id);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use inner::move_window_to_space;
+
+/// Move the window to a specific macOS Space (no-op on non-macOS platforms).
+#[cfg(not(target_os = "macos"))]
+pub fn move_window_to_space(_window: &winit::window::Window, _space_number: u32) -> Result<()> {
+    Ok(())
+}

--- a/src/settings_ui/sidebar.rs
+++ b/src/settings_ui/sidebar.rs
@@ -274,6 +274,12 @@ fn tab_search_keywords(tab: SettingsTab) -> &'static [&'static str] {
             "window type",
             "monitor",
             "target monitor",
+            "space",
+            "spaces",
+            "mission control",
+            "virtual desktop",
+            "macos space",
+            "target space",
             // Tab bar
             "tab bar",
             "tabs",

--- a/src/settings_ui/window_tab.rs
+++ b/src/settings_ui/window_tab.rs
@@ -792,6 +792,45 @@ fn show_behavior_section(
                     "Note: Edge-anchored windows take effect on next window creation",
                 );
             }
+
+            // Target macOS Space setting (only visible on macOS)
+            if cfg!(target_os = "macos") {
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    ui.label("Target Space:");
+                    let mut space_number = settings.config.target_space.unwrap_or(1) as i32;
+                    let mut use_default = settings.config.target_space.is_none();
+
+                    if ui
+                        .checkbox(&mut use_default, "Auto")
+                        .on_hover_text("Let the OS decide which Space (virtual desktop) to open on")
+                        .changed()
+                    {
+                        if use_default {
+                            settings.config.target_space = None;
+                        } else {
+                            settings.config.target_space = Some(1);
+                        }
+                        settings.has_changes = true;
+                        *changes_this_frame = true;
+                    }
+
+                    if !use_default
+                        && ui
+                            .add(egui::Slider::new(&mut space_number, 1..=16))
+                            .on_hover_text("Space number in Mission Control (1 = first Space)")
+                            .changed()
+                    {
+                        settings.config.target_space = Some(space_number as u32);
+                        settings.has_changes = true;
+                        *changes_this_frame = true;
+                    }
+                });
+                ui.colored_label(
+                    egui::Color32::YELLOW,
+                    "Note: Target Space takes effect on next window creation",
+                );
+            }
         },
     );
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -520,6 +520,8 @@ fn test_config_window_management_defaults() {
     assert_eq!(config.window_type, WindowType::Normal);
     // Target monitor should be None (OS decides)
     assert!(config.target_monitor.is_none());
+    // Target Space should be None (OS decides)
+    assert!(config.target_space.is_none());
     // Lock window size should be disabled by default
     assert!(!config.lock_window_size);
     // Show window number should be disabled by default
@@ -616,6 +618,49 @@ target_monitor: null
 "#;
     let config: Config = serde_yaml::from_str(yaml).unwrap();
     assert!(config.target_monitor.is_none());
+}
+
+#[test]
+fn test_config_target_space_default() {
+    let config = Config::default();
+    assert!(config.target_space.is_none());
+}
+
+#[test]
+fn test_config_target_space_yaml_deserialization() {
+    let yaml = r#"
+target_space: 3
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(config.target_space, Some(3));
+}
+
+#[test]
+fn test_config_target_space_null_yaml() {
+    let yaml = r#"
+target_space: null
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert!(config.target_space.is_none());
+}
+
+#[test]
+fn test_config_target_space_yaml_serialization() {
+    let mut config = Config::default();
+    config.target_space = Some(5);
+
+    let yaml = serde_yaml::to_string(&config).unwrap();
+    assert!(yaml.contains("target_space: 5"));
+}
+
+#[test]
+fn test_config_target_space_missing_defaults_to_none() {
+    // When target_space is not in YAML, it should default to None
+    let yaml = r#"
+font_size: 14.0
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert!(config.target_space.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #140

- Add `target_space` config option (1-16, or null for OS default) to specify which macOS Space a window opens in
- New `src/macos_space.rs` module using private SkyLight Server (SLS) APIs, following the same `dlopen`/`dlsym` pattern as `macos_blur.rs`
- Version-aware: uses legacy `SLSMoveWindowsToManagedSpace` on macOS < 14.5, modern compat ID workaround (`SLSSpaceSetCompatID` + `SLSSetWindowListWorkspace`) on 14.5+
- Settings UI control in Window > Window Behavior section (macOS only, Auto checkbox + slider 1-16)
- Sidebar search keywords: space, spaces, mission control, virtual desktop, macos space, target space
- Graceful degradation: warns and continues if SLS APIs are unavailable

## Test plan

- [x] 5 new config tests for `target_space` serialization/deserialization
- [x] All 488+ existing tests pass
- [x] `make fmt-check` clean
- [x] `make lint` (clippy -D warnings) clean
- [ ] Manual: set `target_space: 2` in config, open new window, verify it appears on Space 2
- [ ] Manual: verify Settings UI shows Target Space control on macOS
- [ ] Manual: verify non-existent Space number logs warning gracefully