### PR TITLE
fix: bump par-term-emu-core-rust to 0.38.0 for observer module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,9 +3682,9 @@ dependencies = [
 
 [[package]]
 name = "par-term-emu-core-rust"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc6d9f6dbae03fe99f3f10db585bf15bc4447442d18044f14322fff9b9e06be"
+checksum = "086d61848bc7f9415d9dd784b57cdaad50ec035603c5156d030bfb43284c1d62"
 dependencies = [
  "base64",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 
 [dependencies]
 # Terminal emulator core (with OSC 7/1337 hostname/cwd events, RemoteHost, and OSC 934 named progress bars)
-par-term-emu-core-rust = { version = "0.37.0", default-features = false, features = ["rust-only"] }
+par-term-emu-core-rust = { version = "0.38.0", default-features = false, features = ["rust-only"] }
 
 # Window management and rendering
 winit = "0.30"


### PR DESCRIPTION
## Summary
- Bumps `par-term-emu-core-rust` from 0.37.0 to 0.38.0
- The scripting manager feature (PR #151) uses `observer::{TerminalObserver, ObserverId}` which was added in v0.38.0, but the dependency was pinned to v0.37.0, causing build failures

## Test plan
- [x] `cargo build --release` compiles successfully
- [x] `make bundle-install` completes without error
- [x] All 509 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)