### PR TITLE
refactor(ui): extract Profile types to par-term-config and create par-term-settings-ui (#164)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3746,6 +3746,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "par-term-settings-ui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "dirs",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
+ "image",
+ "log",
+ "open",
+ "par-term-config",
+ "parking_lot",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["par-term-acp", "par-term-config"]
+members = ["par-term-acp", "par-term-config", "par-term-settings-ui"]
 resolver = "2"
 
 [package]

--- a/par-term-config/src/lib.rs
+++ b/par-term-config/src/lib.rs
@@ -9,12 +9,13 @@
 //! - Snippets and automation support
 //! - Configuration file watching
 //! - Status bar widget configuration
-//! - Profile configuration types
+//! - Profile configuration types and manager
 
 pub mod automation;
 pub mod config;
 pub mod defaults;
 pub mod profile;
+pub mod profile_types;
 pub mod scripting;
 pub mod shader_config;
 pub mod shader_metadata;
@@ -51,6 +52,8 @@ pub use snippets::{BuiltInVariable, CustomActionConfig, SnippetConfig, SnippetLi
 pub use status_bar::{StatusBarSection, StatusBarWidgetConfig, WidgetId, default_widgets};
 // Profile configuration
 pub use profile::{ConflictResolution, DynamicProfileSource};
+// Profile types and manager
+pub use profile_types::{Profile, ProfileId, ProfileManager, ProfileSource};
 // Shader config resolution
 pub use shader_config::{resolve_cursor_shader_config, resolve_shader_config};
 // Shader metadata

--- a/par-term-settings-ui/Cargo.toml
+++ b/par-term-settings-ui/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "par-term-settings-ui"
+version = "0.1.0"
+edition = "2024"
+authors = ["Paul Robello <probello@gmail.com>"]
+description = "Settings UI for par-term terminal emulator"
+license = "MIT"
+repository = "https://github.com/paulrobello/par-term"
+homepage = "https://github.com/paulrobello/par-term"
+keywords = ["terminal", "settings", "ui", "egui"]
+categories = ["gui"]
+
+[dependencies]
+# Configuration system (internal)
+par-term-config = { path = "../par-term-config", features = ["wgpu-types"] }
+
+# egui for UI
+egui = "0.33.3"
+egui-wgpu = { version = "0.33.3", optional = true }
+egui-winit = { version = "0.33.3", optional = true }
+
+# File dialogs
+rfd = "0.17.2"
+
+# Serialization
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+
+# Logging
+log = "0.4.29"
+
+# UUID for profile identifiers
+uuid = { version = "1.20", features = ["v4", "serde"] }
+
+# Error handling
+anyhow = "1.0.101"
+
+# Async runtime (for async operations)
+tokio = { version = "1.49", features = ["sync"] }
+
+# Mutex implementation
+parking_lot = "0.12.5"
+
+# Open URLs/files
+open = "5.3.3"
+
+# Date/time for screenshots
+chrono = "0.4.43"
+
+# Image loading
+image = "0.25.9"
+
+# Platform-specific directories
+dirs = "6.0"
+
+[features]
+default = []
+wgpu = ["egui-wgpu", "egui-winit", "par-term-config/wgpu-types"]
+
+[dev-dependencies]
+tempfile = "3.25"

--- a/par-term-settings-ui/src/lib.rs
+++ b/par-term-settings-ui/src/lib.rs
@@ -1,0 +1,196 @@
+//! Settings UI for par-term terminal emulator.
+//!
+//! This crate provides an egui-based settings interface for configuring
+//! terminal options. It is designed to be decoupled from the main terminal
+//! implementation through trait interfaces.
+//!
+//! # Architecture
+//!
+//! The settings UI is separated from the main terminal through the following traits:
+//!
+//! - [`ProfileOperations`]: Profile management operations
+//! - [`ArrangementOperations`]: Window arrangement save/restore
+//! - [`UpdateOperations`]: Self-update checking and installation
+//! - [`CoprocessOperations`]: Coprocess start/stop control
+//! - [`ScriptOperations`]: Script start/stop control
+//!
+//! # Example
+//!
+//! ```ignore
+//! use par_term_settings_ui::{SettingsUI, SettingsContext};
+//!
+//! // Create settings context with implementations
+//! let context = SettingsContext {
+//!     profiles: MyProfileOps,
+//!     arrangements: MyArrangementOps,
+//!     // ... other implementations
+//! };
+//!
+//! // Create settings UI
+//! let mut settings = SettingsUI::new(config, context);
+//!
+//! // Show in egui
+//! let result = settings.show(ctx);
+//! ```
+
+// Public types and traits
+mod traits;
+pub use traits::*;
+
+// Re-export types that settings consumers need
+pub use par_term_config::{
+    Config, Profile, ProfileId, ProfileManager, ProfileSource,
+    BackgroundImageMode, CursorShaderMetadataCache, ShaderMetadataCache,
+    Theme, VsyncMode,
+};
+
+/// Result of shader editor actions
+#[derive(Debug, Clone)]
+pub struct ShaderEditorResult {
+    /// New shader source code to compile and apply
+    pub source: String,
+}
+
+/// Result of cursor shader editor actions
+#[derive(Debug, Clone)]
+pub struct CursorShaderEditorResult {
+    /// New cursor shader source code to compile and apply
+    pub source: String,
+}
+
+/// Actions that can be triggered from the settings UI.
+///
+/// The main application handles these actions after the settings UI
+/// produces them. This allows the settings UI to remain decoupled
+/// from terminal-specific implementations.
+#[derive(Debug, Clone)]
+pub enum SettingsAction {
+    /// No action needed
+    None,
+    /// Close the settings window
+    Close,
+    /// Apply config changes to terminal windows (live update)
+    ApplyConfig(par_term_config::Config),
+    /// Save config to disk
+    SaveConfig(par_term_config::Config),
+    /// Apply background shader from editor
+    ApplyShader(ShaderEditorResult),
+    /// Apply cursor shader from editor
+    ApplyCursorShader(CursorShaderEditorResult),
+    /// Send a test notification to verify permissions
+    TestNotification,
+    /// Save profiles from inline editor to all windows
+    SaveProfiles(Vec<Profile>),
+    /// Open a profile in the focused terminal window
+    OpenProfile(ProfileId),
+    /// Start a coprocess by config index on the active tab
+    StartCoprocess(usize),
+    /// Stop a coprocess by config index on the active tab
+    StopCoprocess(usize),
+    /// Start a script by config index on the active tab
+    StartScript(usize),
+    /// Stop a script by config index on the active tab
+    StopScript(usize),
+    /// Open the debug log file in the system's default editor/viewer
+    OpenLogFile,
+    /// Save the current window layout as an arrangement
+    SaveArrangement {
+        /// Name for the arrangement
+        name: String,
+    },
+    /// Restore a saved window arrangement
+    RestoreArrangement {
+        /// ID of the arrangement to restore
+        id: uuid::Uuid,
+    },
+    /// Delete a saved window arrangement
+    DeleteArrangement {
+        /// ID of the arrangement to delete
+        id: uuid::Uuid,
+    },
+    /// Rename a saved window arrangement
+    RenameArrangement {
+        /// ID of the arrangement to rename
+        id: uuid::Uuid,
+        /// New name for the arrangement
+        new_name: String,
+    },
+    /// User requested an immediate update check
+    ForceUpdateCheck,
+    /// User requested to install the available update
+    InstallUpdate {
+        /// Version to install
+        version: String,
+    },
+    /// Flash pane indices on the terminal window
+    IdentifyPanes,
+}
+
+/// Information about an available update
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    /// Version string (e.g., "v1.2.3")
+    pub version: String,
+    /// Release notes or changelog summary
+    pub release_notes: Option<String>,
+}
+
+/// Result of an update check
+#[derive(Debug, Clone)]
+pub enum UpdateCheckResult {
+    /// No update available
+    UpToDate,
+    /// Update available
+    UpdateAvailable(UpdateInfo),
+    /// Error checking for updates
+    Error(String),
+}
+
+/// Status of a coprocess or script
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessStatus {
+    /// Process is not running
+    Stopped,
+    /// Process is running
+    Running,
+    /// Process failed
+    Failed,
+}
+
+/// Information about a saved window arrangement
+#[derive(Debug, Clone)]
+pub struct ArrangementInfo {
+    /// Unique identifier
+    pub id: uuid::Uuid,
+    /// Display name
+    pub name: String,
+    /// Creation timestamp
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Context containing all trait implementations needed by the settings UI.
+///
+/// This struct is passed to the settings UI to provide access to
+/// terminal-specific operations without creating tight coupling.
+pub struct SettingsContext<
+    P: ProfileOps,
+    A: ArrangementOps,
+    U: UpdateOps,
+    C: CoprocessOps,
+    S: ScriptOps,
+> {
+    /// Profile management operations
+    pub profiles: P,
+    /// Window arrangement operations
+    pub arrangements: A,
+    /// Update checking/installation operations
+    pub updates: U,
+    /// Coprocess management operations
+    pub coprocesses: C,
+    /// Script management operations
+    pub scripts: S,
+}
+
+// Note: The full SettingsUI implementation would be added here.
+// For now, this provides the trait interfaces that the main crate
+// must implement to use this settings UI crate.

--- a/par-term-settings-ui/src/traits.rs
+++ b/par-term-settings-ui/src/traits.rs
@@ -1,0 +1,184 @@
+//! Trait definitions for settings UI dependencies.
+//!
+//! These traits define the interface between the settings UI crate
+//! and the main terminal implementation. The main crate implements
+//! these traits to provide concrete functionality.
+
+use crate::{ArrangementInfo, UpdateCheckResult};
+use par_term_config::{Profile, ProfileId};
+
+/// Profile management operations.
+///
+/// Implemented by the main crate to provide profile management
+/// functionality to the settings UI.
+pub trait ProfileOps {
+    /// Get all profiles in display order
+    fn get_profiles(&self) -> Vec<Profile>;
+
+    /// Save profiles to persistent storage
+    fn save_profiles(&mut self, profiles: Vec<Profile>) -> anyhow::Result<()>;
+
+    /// Get a profile by ID
+    fn get_profile(&self, id: &ProfileId) -> Option<Profile>;
+
+    /// Add or update a profile
+    fn upsert_profile(&mut self, profile: Profile);
+
+    /// Delete a profile by ID
+    fn delete_profile(&mut self, id: &ProfileId) -> bool;
+
+    /// Get available shell options
+    fn get_available_shells(&self) -> Vec<String>;
+}
+
+/// Window arrangement operations.
+///
+/// Implemented by the main crate to provide window layout
+/// save/restore functionality.
+pub trait ArrangementOps {
+    /// Get all saved arrangements
+    fn get_arrangements(&self) -> Vec<ArrangementInfo>;
+
+    /// Save current window layout as a new arrangement
+    fn save_arrangement(&mut self, name: &str) -> anyhow::Result<uuid::Uuid>;
+
+    /// Restore a saved arrangement
+    fn restore_arrangement(&mut self, id: uuid::Uuid) -> anyhow::Result<()>;
+
+    /// Delete a saved arrangement
+    fn delete_arrangement(&mut self, id: uuid::Uuid) -> anyhow::Result<()>;
+
+    /// Rename a saved arrangement
+    fn rename_arrangement(&mut self, id: uuid::Uuid, new_name: &str) -> anyhow::Result<()>;
+
+    /// Check if an arrangement with the given name exists
+    fn arrangement_exists(&self, name: &str) -> bool;
+
+    /// Find arrangement by name
+    fn find_arrangement_by_name(&self, name: &str) -> Option<ArrangementInfo>;
+}
+
+/// Update checking and installation operations.
+///
+/// Implemented by the main crate to provide self-update
+/// functionality.
+pub trait UpdateOps {
+    /// Check for updates (may be async)
+    fn check_for_updates(&self) -> UpdateCheckResult;
+
+    /// Get the last update check result
+    fn last_check_result(&self) -> Option<UpdateCheckResult>;
+
+    /// Install an available update
+    fn install_update(&mut self, version: &str) -> anyhow::Result<()>;
+
+    /// Get update installation status
+    fn is_installing(&self) -> bool;
+
+    /// Get installation progress message
+    fn installation_status(&self) -> Option<String>;
+}
+
+/// Coprocess management operations.
+///
+/// Implemented by the main crate to provide coprocess
+/// control functionality.
+pub trait CoprocessOps {
+    /// Get the number of configured coprocesses
+    fn coprocess_count(&self) -> usize;
+
+    /// Get the running status of a coprocess
+    fn is_running(&self, index: usize) -> bool;
+
+    /// Get the last error from a coprocess
+    fn get_error(&self, index: usize) -> Option<String>;
+
+    /// Get buffered output from a coprocess
+    fn get_output(&self, index: usize) -> Vec<String>;
+
+    /// Start a coprocess
+    fn start(&mut self, index: usize) -> anyhow::Result<()>;
+
+    /// Stop a coprocess
+    fn stop(&mut self, index: usize) -> anyhow::Result<()>;
+
+    /// Clear output buffer for a coprocess
+    fn clear_output(&mut self, index: usize);
+}
+
+/// Script management operations.
+///
+/// Implemented by the main crate to provide script
+/// control functionality.
+pub trait ScriptOps {
+    /// Get the number of configured scripts
+    fn script_count(&self) -> usize;
+
+    /// Get the running status of a script
+    fn is_running(&self, index: usize) -> bool;
+
+    /// Get the last error from a script
+    fn get_error(&self, index: usize) -> Option<String>;
+
+    /// Get buffered output from a script
+    fn get_output(&self, index: usize) -> Vec<String>;
+
+    /// Start a script
+    fn start(&mut self, index: usize) -> anyhow::Result<()>;
+
+    /// Stop a script
+    fn stop(&mut self, index: usize) -> anyhow::Result<()>;
+
+    /// Clear output buffer for a script
+    fn clear_output(&mut self, index: usize);
+
+    /// Get panel state for a script (title, content)
+    fn get_panel(&self, index: usize) -> Option<(String, String)>;
+}
+
+/// Shader management operations.
+///
+/// Implemented by the main crate to provide shader
+/// installation functionality.
+pub trait ShaderOps {
+    /// Install bundled shaders
+    fn install_shaders(&mut self, force_overwrite: bool) -> anyhow::Result<InstallResult>;
+
+    /// Get available shader files
+    fn get_available_shaders(&self) -> Vec<String>;
+
+    /// Get available cubemap prefixes
+    fn get_available_cubemaps(&self) -> Vec<String>;
+
+    /// Get shader directory path
+    fn shaders_dir(&self) -> std::path::PathBuf;
+}
+
+/// Result of a shader installation operation.
+#[derive(Debug, Clone)]
+pub struct InstallResult {
+    /// Number of shaders installed
+    pub installed: usize,
+    /// Number of shaders skipped (unchanged)
+    pub skipped: usize,
+    /// Number of obsolete shaders removed
+    pub removed: usize,
+}
+
+/// Shell integration operations.
+///
+/// Implemented by the main crate to provide shell integration
+/// installation functionality.
+pub trait ShellIntegrationOps {
+    /// Install shell integration for the given shell
+    fn install_integration(&mut self, shell: par_term_config::ShellType) -> anyhow::Result<()>;
+
+    /// Uninstall shell integration for the given shell
+    fn uninstall_integration(&mut self, shell: par_term_config::ShellType) -> anyhow::Result<()>;
+
+    /// Check if shell integration is installed
+    fn is_integration_installed(&self, shell: par_term_config::ShellType) -> bool;
+
+    /// Get the path to the shell integration script
+    fn integration_script_path(&self, shell: par_term_config::ShellType) -> std::path::PathBuf;
+}

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -10,11 +10,12 @@
 
 pub mod dynamic;
 pub mod storage;
-pub mod types;
+// types module is now in par-term-config, re-exported below
 
 pub use dynamic::{
     CacheMeta, ConflictResolution, DynamicProfileManager, DynamicProfileSource,
     DynamicProfileUpdate, FetchResult, SourceStatus, cache_dir, fetch_profiles,
     merge_dynamic_profiles, read_cache, url_to_cache_filename, write_cache,
 };
-pub use types::{Profile, ProfileId, ProfileManager, ProfileSource};
+// Re-export profile types from par-term-config
+pub use par_term_config::{Profile, ProfileId, ProfileManager, ProfileSource};

--- a/src/profile/storage.rs
+++ b/src/profile/storage.rs
@@ -2,7 +2,7 @@
 //!
 //! Profiles are stored in `~/.config/par-term/profiles.yaml`
 
-use super::types::{Profile, ProfileManager};
+use par_term_config::{Profile, ProfileManager};
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary

This is the initial work for extracting the settings UI into a separate crate (#164):

1. **Move Profile types to par-term-config**:
   - `Profile`, `ProfileId`, `ProfileManager`, `ProfileSource`
   - These types have no dependencies on the main crate
   - Makes them available for reuse by other crates

2. **Create `par-term-settings-ui` crate with trait interfaces**:
   - Define trait interfaces for external dependencies (`ProfileOps`, `ArrangementOps`, `UpdateOps`, `CoprocessOps`, `ScriptOps`, `ShaderOps`, `ShellIntegrationOps`)
   - `SettingsAction` enum for UI → main app communication
   - `SettingsContext` struct to pass trait implementations

## Changes

- Created `par-term-config/src/profile_types.rs` with Profile types
- Updated `par-term-config/src/lib.rs` to export new types
- Updated `src/profile/` to re-export from par-term-config
- Removed `src/profile/types.rs` (moved to par-term-config)
- Created `par-term-settings-ui/` crate with trait definitions

## Test Plan

- [x] All tests pass: `cargo test`
- [x] Clippy passes: `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Build succeeds: `cargo build`

## Next Steps

The full `settings_ui` module migration will be completed in a follow-up PR as it requires:
- Implementing the trait interfaces in the main crate
- Gradually moving UI components to use the trait interfaces
- Testing the decoupled implementation

Closes #164 (partial - trait interfaces defined, full extraction in follow-up)