### PR TITLE
refactor(ssh): extract src/ssh/ into par-term-ssh workspace subcrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Refactor**: Collapsed `src/config/` re-export layer — replaced ~4,800 lines of duplicate code with a single `pub use par_term_config::*;`, eliminating all duplicate files (`types.rs`, `defaults.rs`, `snippets.rs`, `shader_config.rs`, `shader_metadata.rs`, `automation.rs`, `scripting.rs`, `watcher.rs`) from `src/config/` (closes #182)
+- **Refactor**: Extracted SSH subsystem into new `par-term-ssh` workspace subcrate — moved ~1,174 lines from `src/ssh/` into dedicated crate with `mdns-sd`, `serde`, and `dirs` dependencies; `src/ssh/mod.rs` is now a thin re-export shim (closes #176)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,6 +3645,7 @@ dependencies = [
  "par-term-fonts",
  "par-term-render",
  "par-term-settings-ui",
+ "par-term-ssh",
  "par-term-terminal",
  "parking_lot",
  "raw-window-handle",
@@ -3794,6 +3795,16 @@ dependencies = [
  "tokio",
  "ureq",
  "uuid",
+]
+
+[[package]]
+name = "par-term-ssh"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "log",
+ "mdns-sd",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["par-term-acp", "par-term-config", "par-term-fonts", "par-term-render", "par-term-settings-ui", "par-term-terminal"]
+members = ["par-term-acp", "par-term-config", "par-term-fonts", "par-term-render", "par-term-settings-ui", "par-term-ssh", "par-term-terminal"]
 resolver = "2"
 
 [package]
@@ -43,6 +43,9 @@ par-term-render = { path = "par-term-render", version = "0.1.0" }
 
 # Settings UI (egui-based settings interface)
 par-term-settings-ui = { path = "par-term-settings-ui", version = "0.1.0" }
+
+# SSH host management and discovery
+par-term-ssh = { path = "par-term-ssh", version = "0.1.0" }
 
 # Terminal emulator core (with OSC 7/1337 hostname/cwd events, RemoteHost, and OSC 934 named progress bars)
 par-term-emu-core-rust = { version = "0.39.0", default-features = false, features = ["rust-only"] }

--- a/par-term-ssh/Cargo.toml
+++ b/par-term-ssh/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "par-term-ssh"
+version = "0.1.0"
+edition = "2024"
+authors = ["Paul Robello <probello@gmail.com>"]
+description = "SSH host management and discovery for par-term terminal emulator"
+license = "MIT"
+repository = "https://github.com/paulrobello/par-term"
+homepage = "https://github.com/paulrobello/par-term"
+keywords = ["terminal", "ssh", "mdns", "discovery"]
+categories = ["network-programming"]
+
+[dependencies]
+# Serialization
+serde = { version = "1.0.228", features = ["derive"] }
+
+# mDNS/Bonjour service discovery for SSH host auto-detection
+mdns-sd = "0.18"
+
+# Platform-specific directories (home dir for ~/.ssh)
+dirs = "6.0"
+
+# Logging
+log = "0.4.29"

--- a/par-term-ssh/src/config_parser.rs
+++ b/par-term-ssh/src/config_parser.rs
@@ -1,0 +1,297 @@
+//! Parser for ~/.ssh/config files.
+//!
+//! Reads SSH config and extracts host entries with their connection parameters.
+
+use super::types::{SshHost, SshHostSource};
+use std::path::Path;
+
+/// Parse an SSH config file and return discovered hosts.
+///
+/// Skips wildcard-only hosts (e.g., `Host *`) since they're defaults, not connectable targets.
+/// Handles multi-host lines like `Host foo bar` by creating separate entries.
+pub fn parse_ssh_config(path: &Path) -> Vec<SshHost> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    parse_ssh_config_str(&content)
+}
+
+/// Parse SSH config from a string (for testing).
+pub fn parse_ssh_config_str(content: &str) -> Vec<SshHost> {
+    let mut hosts = Vec::new();
+    let mut current_aliases: Vec<String> = Vec::new();
+    let mut hostname: Option<String> = None;
+    let mut user: Option<String> = None;
+    let mut port: Option<u16> = None;
+    let mut identity_file: Option<String> = None;
+    let mut proxy_jump: Option<String> = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let (key, value) = if let Some(eq_pos) = line.find('=') {
+            let (k, v) = line.split_at(eq_pos);
+            (k.trim(), v[1..].trim())
+        } else if let Some(space_pos) = line.find(char::is_whitespace) {
+            let (k, v) = line.split_at(space_pos);
+            (k.trim(), v.trim())
+        } else {
+            continue;
+        };
+
+        match key.to_lowercase().as_str() {
+            "host" => {
+                flush_host_block(
+                    &current_aliases,
+                    &hostname,
+                    &user,
+                    &port,
+                    &identity_file,
+                    &proxy_jump,
+                    &mut hosts,
+                );
+
+                current_aliases = value
+                    .split_whitespace()
+                    .filter(|a| !a.contains('*') && !a.contains('?'))
+                    .map(String::from)
+                    .collect();
+                hostname = None;
+                user = None;
+                port = None;
+                identity_file = None;
+                proxy_jump = None;
+            }
+            "hostname" => hostname = Some(value.to_string()),
+            "user" => user = Some(value.to_string()),
+            "port" => port = value.parse().ok(),
+            "identityfile" => {
+                let expanded = if let Some(rest) = value.strip_prefix("~/") {
+                    if let Some(home) = dirs::home_dir() {
+                        format!("{}/{}", home.display(), rest)
+                    } else {
+                        value.to_string()
+                    }
+                } else {
+                    value.to_string()
+                };
+                identity_file = Some(expanded);
+            }
+            "proxyjump" => proxy_jump = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    flush_host_block(
+        &current_aliases,
+        &hostname,
+        &user,
+        &port,
+        &identity_file,
+        &proxy_jump,
+        &mut hosts,
+    );
+
+    hosts
+}
+
+fn flush_host_block(
+    aliases: &[String],
+    hostname: &Option<String>,
+    user: &Option<String>,
+    port: &Option<u16>,
+    identity_file: &Option<String>,
+    proxy_jump: &Option<String>,
+    hosts: &mut Vec<SshHost>,
+) {
+    for alias in aliases {
+        hosts.push(SshHost {
+            alias: alias.clone(),
+            hostname: hostname.clone(),
+            user: user.clone(),
+            port: *port,
+            identity_file: identity_file.clone(),
+            proxy_jump: proxy_jump.clone(),
+            source: SshHostSource::Config,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic_host() {
+        let config = r#"
+Host myserver
+    HostName 192.168.1.100
+    User deploy
+    Port 2222
+"#;
+        let hosts = parse_ssh_config_str(config);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].alias, "myserver");
+        assert_eq!(hosts[0].hostname.as_deref(), Some("192.168.1.100"));
+        assert_eq!(hosts[0].user.as_deref(), Some("deploy"));
+        assert_eq!(hosts[0].port, Some(2222));
+    }
+
+    #[test]
+    fn test_parse_multiple_hosts() {
+        let config = r#"
+Host web
+    HostName web.example.com
+    User www
+
+Host db
+    HostName db.example.com
+    User postgres
+    Port 5432
+"#;
+        let hosts = parse_ssh_config_str(config);
+        assert_eq!(hosts.len(), 2);
+        assert_eq!(hosts[0].alias, "web");
+        assert_eq!(hosts[1].alias, "db");
+    }
+
+    #[test]
+    fn test_skip_wildcard_hosts() {
+        let config = r#"
+Host *
+    ServerAliveInterval 60
+
+Host *.example.com
+    User admin
+
+Host myserver
+    HostName 10.0.0.1
+"#;
+        let hosts = parse_ssh_config_str(config);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].alias, "myserver");
+    }
+
+    #[test]
+    fn test_multi_alias_host_line() {
+        let config = r#"
+Host foo bar
+    HostName shared.example.com
+    User shared
+"#;
+        let hosts = parse_ssh_config_str(config);
+        assert_eq!(hosts.len(), 2);
+        assert_eq!(hosts[0].alias, "foo");
+        assert_eq!(hosts[1].alias, "bar");
+        assert_eq!(hosts[0].hostname, hosts[1].hostname);
+    }
+
+    #[test]
+    fn test_proxy_jump() {
+        let config = r#"
+Host internal
+    HostName 10.0.0.5
+    ProxyJump bastion
+"#;
+        let hosts = parse_ssh_config_str(config);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].proxy_jump.as_deref(), Some("bastion"));
+    }
+
+    #[test]
+    fn test_identity_file_tilde_expansion() {
+        let config = r#"
+Host myhost
+    IdentityFile ~/.ssh/id_work
+"#;
+        let hosts = parse_ssh_config_str(config);
+        assert_eq!(hosts.len(), 1);
+        assert!(hosts[0].identity_file.is_some());
+        assert!(!hosts[0].identity_file.as_ref().unwrap().starts_with("~"));
+    }
+
+    #[test]
+    fn test_equals_syntax() {
+        let config = r#"
+Host eqhost
+    HostName=eq.example.com
+    User=equser
+    Port=3022
+"#;
+        let hosts = parse_ssh_config_str(config);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].hostname.as_deref(), Some("eq.example.com"));
+        assert_eq!(hosts[0].user.as_deref(), Some("equser"));
+        assert_eq!(hosts[0].port, Some(3022));
+    }
+
+    #[test]
+    fn test_comments_and_empty_lines() {
+        let config = r#"
+# This is a comment
+Host server1
+    # HostName commented.out
+    HostName real.example.com
+
+    User admin
+"#;
+        let hosts = parse_ssh_config_str(config);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].hostname.as_deref(), Some("real.example.com"));
+    }
+
+    #[test]
+    fn test_empty_config() {
+        let hosts = parse_ssh_config_str("");
+        assert!(hosts.is_empty());
+    }
+
+    #[test]
+    fn test_ssh_args_basic() {
+        let host = SshHost {
+            alias: "myhost".to_string(),
+            hostname: Some("10.0.0.1".to_string()),
+            user: Some("deploy".to_string()),
+            port: Some(2222),
+            identity_file: None,
+            proxy_jump: None,
+            source: SshHostSource::Config,
+        };
+        let args = host.ssh_args();
+        assert_eq!(args, vec!["-p", "2222", "deploy@10.0.0.1"]);
+    }
+
+    #[test]
+    fn test_ssh_args_default_port() {
+        let host = SshHost {
+            alias: "myhost".to_string(),
+            hostname: Some("10.0.0.1".to_string()),
+            user: None,
+            port: Some(22),
+            identity_file: None,
+            proxy_jump: None,
+            source: SshHostSource::Config,
+        };
+        let args = host.ssh_args();
+        assert_eq!(args, vec!["10.0.0.1"]);
+    }
+
+    #[test]
+    fn test_connection_string() {
+        let host = SshHost {
+            alias: "myhost".to_string(),
+            hostname: Some("10.0.0.1".to_string()),
+            user: Some("deploy".to_string()),
+            port: Some(2222),
+            identity_file: None,
+            proxy_jump: None,
+            source: SshHostSource::Config,
+        };
+        assert_eq!(host.connection_string(), "deploy@10.0.0.1:2222");
+    }
+}

--- a/par-term-ssh/src/discovery.rs
+++ b/par-term-ssh/src/discovery.rs
@@ -1,0 +1,86 @@
+//! SSH host discovery aggregator.
+
+use super::config_parser;
+use super::history;
+use super::known_hosts;
+use super::types::SshHost;
+use std::collections::HashSet;
+
+/// Discover SSH hosts from all local sources (config, known_hosts, history).
+pub fn discover_local_hosts() -> Vec<SshHost> {
+    let mut all_hosts = Vec::new();
+    let mut seen = HashSet::new();
+
+    if let Some(home) = dirs::home_dir() {
+        let ssh_dir = home.join(".ssh");
+
+        let config_path = ssh_dir.join("config");
+        if config_path.exists() {
+            for host in config_parser::parse_ssh_config(&config_path) {
+                let key = dedup_key(&host);
+                if seen.insert(key) {
+                    all_hosts.push(host);
+                }
+            }
+        }
+
+        let known_hosts_path = ssh_dir.join("known_hosts");
+        if known_hosts_path.exists() {
+            for host in known_hosts::parse_known_hosts(&known_hosts_path) {
+                let key = dedup_key(&host);
+                if seen.insert(key) {
+                    all_hosts.push(host);
+                }
+            }
+        }
+    }
+
+    for host in history::scan_history() {
+        let key = dedup_key(&host);
+        if seen.insert(key) {
+            all_hosts.push(host);
+        }
+    }
+
+    all_hosts
+}
+
+fn dedup_key(host: &SshHost) -> String {
+    let target = host.hostname.as_deref().unwrap_or(&host.alias);
+    let port = host.port.unwrap_or(22);
+    format!("{}:{}", target.to_lowercase(), port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::SshHostSource;
+
+    #[test]
+    fn test_dedup_key() {
+        let host = SshHost {
+            alias: "myhost".to_string(),
+            hostname: Some("MyHost.Example.COM".to_string()),
+            user: None,
+            port: None,
+            identity_file: None,
+            proxy_jump: None,
+            source: SshHostSource::Config,
+        };
+        assert_eq!(dedup_key(&host), "myhost.example.com:22");
+    }
+
+    #[test]
+    fn test_dedup_key_with_port() {
+        let host = SshHost {
+            alias: "myhost".to_string(),
+            hostname: Some("myhost.example.com".to_string()),
+            user: None,
+            port: Some(2222),
+            identity_file: None,
+            proxy_jump: None,
+            source: SshHostSource::Config,
+        };
+        assert_eq!(dedup_key(&host), "myhost.example.com:2222");
+    }
+}

--- a/par-term-ssh/src/history.rs
+++ b/par-term-ssh/src/history.rs
@@ -1,0 +1,236 @@
+//! Shell history scanner for SSH commands.
+
+use super::types::{SshHost, SshHostSource};
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Scan shell history files for SSH commands.
+pub fn scan_history() -> Vec<SshHost> {
+    let mut hosts = Vec::new();
+    let mut seen = HashSet::new();
+
+    if let Some(home) = dirs::home_dir() {
+        let bash_hist = home.join(".bash_history");
+        if bash_hist.exists() {
+            scan_history_file(&bash_hist, false, &mut hosts, &mut seen);
+        }
+
+        let zsh_hist = home.join(".zsh_history");
+        if zsh_hist.exists() {
+            scan_history_file(&zsh_hist, true, &mut hosts, &mut seen);
+        }
+
+        let fish_hist = home.join(".local/share/fish/fish_history");
+        if fish_hist.exists() {
+            scan_fish_history(&fish_hist, &mut hosts, &mut seen);
+        }
+    }
+
+    hosts
+}
+
+fn scan_history_file(
+    path: &Path,
+    is_zsh: bool,
+    hosts: &mut Vec<SshHost>,
+    seen: &mut HashSet<String>,
+) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    for line in content.lines() {
+        let line = if is_zsh {
+            line.split_once(';').map(|(_, cmd)| cmd).unwrap_or(line)
+        } else {
+            line
+        };
+
+        if let Some(host) = parse_ssh_command(line) {
+            let key = host.connection_string();
+            if !seen.contains(&key) {
+                seen.insert(key);
+                hosts.push(host);
+            }
+        }
+    }
+}
+
+fn scan_fish_history(path: &Path, hosts: &mut Vec<SshHost>, seen: &mut HashSet<String>) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(cmd) = line.strip_prefix("- cmd: ")
+            && let Some(host) = parse_ssh_command(cmd)
+        {
+            let key = host.connection_string();
+            if !seen.contains(&key) {
+                seen.insert(key);
+                hosts.push(host);
+            }
+        }
+    }
+}
+
+/// Parse an SSH command line and extract host info.
+pub fn parse_ssh_command(line: &str) -> Option<SshHost> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+
+    let ssh_idx = parts.iter().position(|&p| p == "ssh")?;
+    let args = &parts[ssh_idx + 1..];
+
+    if args.is_empty() {
+        return None;
+    }
+
+    let mut port: Option<u16> = None;
+    let mut identity: Option<String> = None;
+    let mut target: Option<&str> = None;
+    let mut i = 0;
+
+    while i < args.len() {
+        match args[i] {
+            "-p" => {
+                if i + 1 < args.len() {
+                    port = args[i + 1].parse().ok();
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            "-i" => {
+                if i + 1 < args.len() {
+                    identity = Some(args[i + 1].to_string());
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            "-J" => {
+                i += 2;
+            }
+            arg if arg.starts_with('-') => {
+                let takes_value = matches!(
+                    arg,
+                    "-b" | "-c"
+                        | "-D"
+                        | "-E"
+                        | "-e"
+                        | "-F"
+                        | "-I"
+                        | "-L"
+                        | "-l"
+                        | "-m"
+                        | "-O"
+                        | "-o"
+                        | "-Q"
+                        | "-R"
+                        | "-S"
+                        | "-W"
+                        | "-w"
+                );
+                if takes_value && i + 1 < args.len() {
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            arg => {
+                if target.is_none() {
+                    target = Some(arg);
+                }
+                i += 1;
+            }
+        }
+    }
+
+    let target = target?;
+
+    if target.starts_with('/') || target.starts_with('.') || target.contains('=') {
+        return None;
+    }
+
+    let (user, hostname) = if let Some((u, h)) = target.split_once('@') {
+        (Some(u.to_string()), h.to_string())
+    } else {
+        (None, target.to_string())
+    };
+
+    if hostname.is_empty() || hostname.starts_with('-') {
+        return None;
+    }
+
+    Some(SshHost {
+        alias: hostname.clone(),
+        hostname: Some(hostname),
+        user,
+        port,
+        identity_file: identity,
+        proxy_jump: None,
+        source: SshHostSource::History,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_ssh() {
+        let host = parse_ssh_command("ssh myhost.com").unwrap();
+        assert_eq!(host.alias, "myhost.com");
+        assert_eq!(host.user, None);
+        assert_eq!(host.port, None);
+    }
+
+    #[test]
+    fn test_parse_user_at_host() {
+        let host = parse_ssh_command("ssh deploy@myhost.com").unwrap();
+        assert_eq!(host.alias, "myhost.com");
+        assert_eq!(host.user.as_deref(), Some("deploy"));
+    }
+
+    #[test]
+    fn test_parse_with_port() {
+        let host = parse_ssh_command("ssh -p 2222 myhost.com").unwrap();
+        assert_eq!(host.port, Some(2222));
+    }
+
+    #[test]
+    fn test_parse_with_identity() {
+        let host = parse_ssh_command("ssh -i ~/.ssh/id_work myhost.com").unwrap();
+        assert_eq!(host.identity_file.as_deref(), Some("~/.ssh/id_work"));
+    }
+
+    #[test]
+    fn test_parse_complex_command() {
+        let host =
+            parse_ssh_command("ssh -p 2222 -i ~/.ssh/key deploy@server.example.com").unwrap();
+        assert_eq!(host.alias, "server.example.com");
+        assert_eq!(host.user.as_deref(), Some("deploy"));
+        assert_eq!(host.port, Some(2222));
+        assert_eq!(host.identity_file.as_deref(), Some("~/.ssh/key"));
+    }
+
+    #[test]
+    fn test_skip_non_ssh() {
+        assert!(parse_ssh_command("ls -la").is_none());
+        assert!(parse_ssh_command("git push").is_none());
+    }
+
+    #[test]
+    fn test_skip_ssh_only() {
+        assert!(parse_ssh_command("ssh").is_none());
+    }
+
+    #[test]
+    fn test_ssh_with_preceding_command() {
+        let host = parse_ssh_command("TERM=xterm ssh myhost.com").unwrap();
+        assert_eq!(host.alias, "myhost.com");
+    }
+}

--- a/par-term-ssh/src/known_hosts.rs
+++ b/par-term-ssh/src/known_hosts.rs
@@ -1,0 +1,144 @@
+//! Parser for ~/.ssh/known_hosts files.
+//!
+//! Extracts hostnames from known_hosts entries. Handles both plain and
+//! hashed hostname formats, as well as bracketed [host]:port entries.
+
+use super::types::{SshHost, SshHostSource};
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Parse a known_hosts file and return discovered hosts.
+pub fn parse_known_hosts(path: &Path) -> Vec<SshHost> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    parse_known_hosts_str(&content)
+}
+
+/// Parse known_hosts from a string (for testing).
+pub fn parse_known_hosts_str(content: &str) -> Vec<SshHost> {
+    let mut seen = HashSet::new();
+    let mut hosts = Vec::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        if line.is_empty() || line.starts_with('#') || line.starts_with('@') {
+            continue;
+        }
+
+        let host_field = match line.split_whitespace().next() {
+            Some(f) => f,
+            None => continue,
+        };
+
+        if host_field.starts_with("|1|") {
+            continue;
+        }
+
+        for entry in host_field.split(',') {
+            let (hostname, port) = parse_host_entry(entry);
+
+            if hostname.is_empty() {
+                continue;
+            }
+
+            let key = format!("{}:{}", hostname, port.unwrap_or(22));
+            if seen.contains(&key) {
+                continue;
+            }
+            seen.insert(key);
+
+            hosts.push(SshHost {
+                alias: hostname.clone(),
+                hostname: Some(hostname),
+                user: None,
+                port,
+                identity_file: None,
+                proxy_jump: None,
+                source: SshHostSource::KnownHosts,
+            });
+        }
+    }
+
+    hosts
+}
+
+fn parse_host_entry(entry: &str) -> (String, Option<u16>) {
+    if entry.starts_with('[') {
+        if let Some(bracket_end) = entry.find(']') {
+            let hostname = entry[1..bracket_end].to_string();
+            let port = entry[bracket_end + 1..]
+                .strip_prefix(':')
+                .and_then(|p| p.parse().ok());
+            (hostname, port)
+        } else {
+            (entry.to_string(), None)
+        }
+    } else {
+        (entry.to_string(), None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic_entries() {
+        let content = "github.com ssh-ed25519 AAAAC3...\nbitbucket.org ssh-rsa AAAAB3...\n";
+        let hosts = parse_known_hosts_str(content);
+        assert_eq!(hosts.len(), 2);
+        assert_eq!(hosts[0].alias, "github.com");
+        assert_eq!(hosts[1].alias, "bitbucket.org");
+    }
+
+    #[test]
+    fn test_skip_hashed_entries() {
+        let content = "|1|abc123|def456 ssh-rsa AAAAB3...\ngithub.com ssh-ed25519 AAAA...\n";
+        let hosts = parse_known_hosts_str(content);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].alias, "github.com");
+    }
+
+    #[test]
+    fn test_bracketed_port() {
+        let content = "[myhost.example.com]:2222 ssh-rsa AAAAB3...\n";
+        let hosts = parse_known_hosts_str(content);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].alias, "myhost.example.com");
+        assert_eq!(hosts[0].port, Some(2222));
+    }
+
+    #[test]
+    fn test_comma_separated_hostnames() {
+        let content = "host1.example.com,192.168.1.1 ssh-rsa AAAAB3...\n";
+        let hosts = parse_known_hosts_str(content);
+        assert_eq!(hosts.len(), 2);
+        assert_eq!(hosts[0].alias, "host1.example.com");
+        assert_eq!(hosts[1].alias, "192.168.1.1");
+    }
+
+    #[test]
+    fn test_dedup() {
+        let content = "host.com ssh-rsa AAAA...\nhost.com ssh-ed25519 AAAA...\n";
+        let hosts = parse_known_hosts_str(content);
+        assert_eq!(hosts.len(), 1);
+    }
+
+    #[test]
+    fn test_skip_comments_and_markers() {
+        let content =
+            "# comment\n@cert-authority *.example.com ssh-rsa AAAA...\nreal.host ssh-rsa AAAA...\n";
+        let hosts = parse_known_hosts_str(content);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].alias, "real.host");
+    }
+
+    #[test]
+    fn test_empty() {
+        let hosts = parse_known_hosts_str("");
+        assert!(hosts.is_empty());
+    }
+}

--- a/par-term-ssh/src/lib.rs
+++ b/par-term-ssh/src/lib.rs
@@ -1,0 +1,14 @@
+//! SSH subsystem for par-term terminal emulator.
+//!
+//! Provides SSH config parsing, known_hosts scanning, shell history extraction,
+//! and mDNS/Bonjour discovery for SSH hosts.
+
+pub mod config_parser;
+pub mod discovery;
+pub mod history;
+pub mod known_hosts;
+pub mod mdns;
+pub mod types;
+
+pub use discovery::discover_local_hosts;
+pub use types::{SshHost, SshHostSource};

--- a/par-term-ssh/src/mdns.rs
+++ b/par-term-ssh/src/mdns.rs
@@ -1,0 +1,291 @@
+//! mDNS/Bonjour discovery for SSH hosts on the local network.
+//!
+//! Uses the `mdns-sd` crate to browse for `_ssh._tcp.local.` services.
+//! Discovery runs asynchronously and sends results via an mpsc channel.
+
+use super::types::{SshHost, SshHostSource};
+use mdns_sd::{ServiceDaemon, ServiceEvent};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// mDNS discovery state.
+pub struct MdnsDiscovery {
+    /// Discovered hosts from mDNS
+    discovered: Vec<SshHost>,
+    /// Whether a scan is currently running
+    scanning: bool,
+    /// Receiver for hosts from background scan
+    receiver: Option<mpsc::Receiver<SshHost>>,
+}
+
+impl Default for MdnsDiscovery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MdnsDiscovery {
+    pub fn new() -> Self {
+        Self {
+            discovered: Vec::new(),
+            scanning: false,
+            receiver: None,
+        }
+    }
+
+    /// Start an mDNS scan for SSH services.
+    pub fn start_scan(&mut self, timeout_secs: u32) {
+        if self.scanning {
+            return;
+        }
+
+        self.scanning = true;
+        self.discovered.clear();
+
+        let (tx, rx) = mpsc::channel();
+        self.receiver = Some(rx);
+
+        let timeout = Duration::from_secs(u64::from(timeout_secs));
+
+        std::thread::spawn(move || {
+            run_mdns_scan(tx, timeout);
+        });
+    }
+
+    /// Poll for newly discovered hosts. Returns true if new hosts were found.
+    pub fn poll(&mut self) -> bool {
+        let receiver = match &self.receiver {
+            Some(r) => r,
+            None => return false,
+        };
+
+        let mut found_new = false;
+
+        // Drain all available hosts from the channel
+        loop {
+            match receiver.try_recv() {
+                Ok(host) => {
+                    let duplicate = self
+                        .discovered
+                        .iter()
+                        .any(|h| h.hostname == host.hostname && h.port == host.port);
+                    if !duplicate {
+                        self.discovered.push(host);
+                        found_new = true;
+                    }
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    // Scan thread has finished
+                    self.scanning = false;
+                    self.receiver = None;
+                    break;
+                }
+            }
+        }
+
+        found_new
+    }
+
+    /// Returns the list of discovered hosts.
+    pub fn hosts(&self) -> &[SshHost] {
+        &self.discovered
+    }
+
+    /// Returns whether a scan is currently in progress.
+    pub fn is_scanning(&self) -> bool {
+        self.scanning
+    }
+
+    /// Clear all discovered hosts and stop any in-progress scan.
+    pub fn clear(&mut self) {
+        self.discovered.clear();
+        self.scanning = false;
+        self.receiver = None;
+    }
+}
+
+/// Run an mDNS scan in a background thread, sending discovered SSH hosts
+/// through the provided channel.
+fn run_mdns_scan(tx: mpsc::Sender<SshHost>, timeout: Duration) {
+    let daemon = match ServiceDaemon::new() {
+        Ok(d) => d,
+        Err(e) => {
+            log::warn!("Failed to start mDNS daemon: {}", e);
+            return;
+        }
+    };
+
+    let receiver = match daemon.browse("_ssh._tcp.local.") {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!("Failed to browse mDNS: {}", e);
+            let _ = daemon.shutdown();
+            return;
+        }
+    };
+
+    let deadline = std::time::Instant::now() + timeout;
+
+    loop {
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match receiver.recv_timeout(remaining.min(Duration::from_millis(500))) {
+            Ok(ServiceEvent::ServiceResolved(info)) => {
+                let hostname = info.get_hostname().trim_end_matches('.').to_string();
+                let port = info.get_port();
+                let service_name = info
+                    .get_fullname()
+                    .split("._ssh._tcp")
+                    .next()
+                    .unwrap_or(&hostname)
+                    .to_string();
+
+                let host = SshHost {
+                    alias: service_name,
+                    hostname: Some(hostname),
+                    user: None,
+                    port: if port == 22 { None } else { Some(port) },
+                    identity_file: None,
+                    proxy_jump: None,
+                    source: SshHostSource::Mdns,
+                };
+
+                if tx.send(host).is_err() {
+                    break;
+                }
+            }
+            Ok(_) => {
+                // Ignore other events (SearchStarted, ServiceFound, etc.)
+            }
+            Err(_) if receiver.is_disconnected() => break,
+            Err(_) => continue, // Timeout — keep waiting
+        }
+    }
+
+    let _ = daemon.shutdown();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mdns_discovery_new() {
+        let discovery = MdnsDiscovery::new();
+        assert!(!discovery.is_scanning());
+        assert!(discovery.hosts().is_empty());
+    }
+
+    #[test]
+    fn test_mdns_discovery_default() {
+        let discovery = MdnsDiscovery::default();
+        assert!(!discovery.is_scanning());
+        assert!(discovery.hosts().is_empty());
+    }
+
+    #[test]
+    fn test_mdns_discovery_clear() {
+        let mut discovery = MdnsDiscovery::new();
+        discovery.discovered.push(SshHost {
+            alias: "test".to_string(),
+            hostname: Some("test.local".to_string()),
+            user: None,
+            port: None,
+            identity_file: None,
+            proxy_jump: None,
+            source: SshHostSource::Mdns,
+        });
+        assert_eq!(discovery.hosts().len(), 1);
+
+        discovery.clear();
+        assert!(discovery.hosts().is_empty());
+        assert!(!discovery.is_scanning());
+    }
+
+    #[test]
+    fn test_poll_without_scan() {
+        let mut discovery = MdnsDiscovery::new();
+        // Should return false when no scan is running
+        assert!(!discovery.poll());
+    }
+
+    #[test]
+    fn test_poll_with_completed_channel() {
+        let mut discovery = MdnsDiscovery::new();
+        let (tx, rx) = mpsc::channel();
+        discovery.receiver = Some(rx);
+        discovery.scanning = true;
+
+        // Send a host then drop the sender to simulate scan completion
+        tx.send(SshHost {
+            alias: "myhost".to_string(),
+            hostname: Some("myhost.local".to_string()),
+            user: None,
+            port: None,
+            identity_file: None,
+            proxy_jump: None,
+            source: SshHostSource::Mdns,
+        })
+        .unwrap();
+        drop(tx);
+
+        // First poll should find the host
+        let found = discovery.poll();
+        assert!(found);
+        assert_eq!(discovery.hosts().len(), 1);
+        assert_eq!(discovery.hosts()[0].alias, "myhost");
+        assert_eq!(
+            discovery.hosts()[0].hostname.as_deref(),
+            Some("myhost.local")
+        );
+    }
+
+    #[test]
+    fn test_poll_deduplicates() {
+        let mut discovery = MdnsDiscovery::new();
+        let (tx, rx) = mpsc::channel();
+        discovery.receiver = Some(rx);
+        discovery.scanning = true;
+
+        // Send two hosts with the same hostname and port
+        for _ in 0..2 {
+            tx.send(SshHost {
+                alias: "dup".to_string(),
+                hostname: Some("dup.local".to_string()),
+                user: None,
+                port: None,
+                identity_file: None,
+                proxy_jump: None,
+                source: SshHostSource::Mdns,
+            })
+            .unwrap();
+        }
+        drop(tx);
+
+        discovery.poll();
+        assert_eq!(discovery.hosts().len(), 1);
+    }
+
+    #[test]
+    fn test_scan_marks_scanning() {
+        let mut discovery = MdnsDiscovery::new();
+        assert!(!discovery.is_scanning());
+
+        // Starting a scan sets the scanning flag
+        discovery.start_scan(1);
+        assert!(discovery.is_scanning());
+
+        // Wait for background thread to finish
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Poll until scan completes
+        for _ in 0..10 {
+            discovery.poll();
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}

--- a/par-term-ssh/src/types.rs
+++ b/par-term-ssh/src/types.rs
@@ -1,0 +1,106 @@
+//! SSH host types for the SSH subsystem.
+
+use serde::{Deserialize, Serialize};
+
+/// Source of an SSH host entry
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SshHostSource {
+    /// Parsed from ~/.ssh/config
+    Config,
+    /// Found in ~/.ssh/known_hosts
+    KnownHosts,
+    /// Extracted from shell history
+    History,
+    /// Discovered via mDNS/Bonjour
+    Mdns,
+}
+
+impl std::fmt::Display for SshHostSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Config => write!(f, "SSH Config"),
+            Self::KnownHosts => write!(f, "Known Hosts"),
+            Self::History => write!(f, "History"),
+            Self::Mdns => write!(f, "mDNS"),
+        }
+    }
+}
+
+/// A discovered SSH host with connection details
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SshHost {
+    /// The Host alias from SSH config, or hostname from other sources
+    pub alias: String,
+    /// Resolved hostname or IP address
+    pub hostname: Option<String>,
+    /// SSH username
+    pub user: Option<String>,
+    /// SSH port (None means default 22)
+    pub port: Option<u16>,
+    /// Path to identity file
+    pub identity_file: Option<String>,
+    /// ProxyJump host
+    pub proxy_jump: Option<String>,
+    /// Where this host was discovered from
+    pub source: SshHostSource,
+}
+
+impl SshHost {
+    /// Get the display name for this host (alias or hostname)
+    pub fn display_name(&self) -> &str {
+        &self.alias
+    }
+
+    /// Get the connection target (hostname or alias)
+    pub fn connection_target(&self) -> &str {
+        self.hostname.as_deref().unwrap_or(&self.alias)
+    }
+
+    /// Build the ssh command arguments for connecting to this host
+    pub fn ssh_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if let Some(port) = self.port
+            && port != 22
+        {
+            args.push("-p".to_string());
+            args.push(port.to_string());
+        }
+
+        if let Some(ref identity) = self.identity_file {
+            args.push("-i".to_string());
+            args.push(identity.clone());
+        }
+
+        if let Some(ref proxy) = self.proxy_jump {
+            args.push("-J".to_string());
+            args.push(proxy.clone());
+        }
+
+        let target = if let Some(ref user) = self.user {
+            format!("{}@{}", user, self.connection_target())
+        } else {
+            self.connection_target().to_string()
+        };
+        args.push(target);
+
+        args
+    }
+
+    /// Build a display string showing user@host:port
+    pub fn connection_string(&self) -> String {
+        let mut s = String::new();
+        if let Some(ref user) = self.user {
+            s.push_str(user);
+            s.push('@');
+        }
+        s.push_str(self.connection_target());
+        if let Some(port) = self.port
+            && port != 22
+        {
+            s.push(':');
+            s.push_str(&port.to_string());
+        }
+        s
+    }
+}

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -1,14 +1,6 @@
-//! SSH subsystem for host management, discovery, and quick connect.
-//!
-//! Provides SSH config parsing, known_hosts scanning, shell history extraction,
-//! and mDNS/Bonjour discovery for SSH hosts.
+//! SSH subsystem re-exports from the `par-term-ssh` crate.
 
-pub mod config_parser;
-pub mod discovery;
-pub mod history;
-pub mod known_hosts;
-pub mod mdns;
-pub mod types;
+pub use par_term_ssh::*;
 
-pub use discovery::discover_local_hosts;
-pub use types::{SshHost, SshHostSource};
+// Re-export submodules for backward compatibility
+pub use par_term_ssh::mdns;


### PR DESCRIPTION
## Summary

Closes #176

Extracts the SSH subsystem from `src/ssh/` into a new `par-term-ssh` workspace subcrate.

## Changes

- Created `par-term-ssh/` workspace subcrate with `Cargo.toml` and all SSH source files
- `src/ssh/mod.rs` replaced with thin `pub use par_term_ssh::*;` re-export shim
- Added `par-term-ssh` to workspace members and main crate dependencies

## Files Moved

- `src/ssh/types.rs` → `par-term-ssh/src/types.rs`
- `src/ssh/config_parser.rs` → `par-term-ssh/src/config_parser.rs`
- `src/ssh/discovery.rs` → `par-term-ssh/src/discovery.rs`
- `src/ssh/history.rs` → `par-term-ssh/src/history.rs`
- `src/ssh/known_hosts.rs` → `par-term-ssh/src/known_hosts.rs`
- `src/ssh/mdns.rs` → `par-term-ssh/src/mdns.rs`

## Test plan

- [x] `cargo check` — no errors
- [x] `make build` — builds successfully
- [x] `make test` — all tests pass