### PR TITLE
refactor(config): move PaneId and TabId to par-term-config for shared access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Refactor**: Extracted update system into new `par-term-update` workspace subcrate — moved ~1,170 lines from `src/manifest.rs`, `src/self_updater.rs`, `src/update_checker.rs` into dedicated crate; heavy deps (`zip`, `sha2`, `ureq`, `semver`, `chrono`) isolated from main crate; source files replaced with re-export shims (closes #179)
 - **Refactor**: Extracted input handler into new `par-term-input` workspace subcrate — moved ~505 lines from `src/input.rs` into dedicated crate with `par-term-config`, `arboard`, and `winit` dependencies; `src/input.rs` is now a thin re-export shim (closes #180)
 - **Refactor**: Extracted MCP stdio server into new `par-term-mcp` workspace subcrate — moved ~580 lines from `src/mcp_server.rs` into dedicated crate with only `serde`, `serde_json`, and `dirs` dependencies; zero internal crate dependencies make it independently publishable (closes #181)
+- **Refactor**: Moved `PaneId` and `TabId` type definitions into `par-term-config` for shared access across subcrates — `src/pane/types.rs` and `src/tab/mod.rs` now re-export from `par-term-config`; `src/tmux/sync.rs` imports directly from `par-term-config`, removing its internal crate coupling (closes #183)
 
 ---
 

--- a/par-term-config/src/lib.rs
+++ b/par-term-config/src/lib.rs
@@ -40,12 +40,12 @@ pub use types::{
     CursorShaderMetadata, CursorStyle, DividerRect, DividerStyle, DownloadSaveLocation,
     DroppedFileQuoteStyle, FontRange, ImageScalingMode, InstallPromptState, IntegrationVersions,
     KeyBinding, LogLevel, ModifierRemapping, ModifierTarget, OptionKeyMode, PaneBackground,
-    PaneBackgroundConfig, PaneTitlePosition, PowerPreference, ProgressBarPosition,
+    PaneBackgroundConfig, PaneId, PaneTitlePosition, PowerPreference, ProgressBarPosition,
     ProgressBarStyle, SemanticHistoryEditorMode, SeparatorMark, SessionLogFormat, ShaderConfig,
     ShaderInstallPrompt, ShaderMetadata, ShellExitAction, ShellType, SmartSelectionPrecision,
     SmartSelectionRule, StartupDirectoryMode, StatusBarPosition, TabBarMode, TabBarPosition,
-    TabStyle, ThinStrokesMode, UnfocusedCursorStyle, UpdateCheckFrequency, VsyncMode, WindowType,
-    default_smart_selection_rules,
+    TabId, TabStyle, ThinStrokesMode, UnfocusedCursorStyle, UpdateCheckFrequency, VsyncMode,
+    WindowType, default_smart_selection_rules,
 };
 // KeyModifier is exported for potential future use (e.g., custom keybinding UI)
 pub use automation::{CoprocessDefConfig, RestartPolicy, TriggerActionConfig, TriggerConfig};

--- a/par-term-config/src/types.rs
+++ b/par-term-config/src/types.rs
@@ -1561,3 +1561,13 @@ impl DividerRect {
 
 /// Visible command separator mark: (row, col_offset, optional_color)
 pub type SeparatorMark = (usize, Option<i32>, Option<(u8, u8, u8)>);
+
+// ============================================================================
+// Shared ID Types
+// ============================================================================
+
+/// Unique identifier for a pane
+pub type PaneId = u64;
+
+/// Unique identifier for a tab
+pub type TabId = u64;

--- a/src/pane/types.rs
+++ b/src/pane/types.rs
@@ -18,8 +18,8 @@ use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-/// Unique identifier for a pane
-pub type PaneId = u64;
+// Re-export PaneId from par-term-config for shared access across subcrates
+pub use par_term_config::PaneId;
 
 /// State for shell restart behavior
 #[derive(Debug, Clone)]

--- a/src/tab/mod.rs
+++ b/src/tab/mod.rs
@@ -289,8 +289,8 @@ fn apply_login_shell_flag(_shell_args: &mut Option<Vec<String>>, _config: &Confi
     // No-op on Windows
 }
 
-/// Unique identifier for a tab
-pub type TabId = u64;
+// Re-export TabId from par-term-config for shared access across subcrates
+pub use par_term_config::TabId;
 
 /// A single terminal tab with its own state (supports split panes)
 pub struct Tab {

--- a/src/tmux/sync.rs
+++ b/src/tmux/sync.rs
@@ -8,8 +8,7 @@
 
 use super::session::TmuxNotification;
 use super::types::{TmuxPaneId, TmuxWindowId};
-use crate::pane::PaneId;
-use crate::tab::TabId;
+use par_term_config::{PaneId, TabId};
 use std::collections::HashMap;
 
 /// Synchronizes state between tmux and par-term


### PR DESCRIPTION
## Summary

- Adds `PaneId = u64` and `TabId = u64` to `par-term-config/src/types.rs` and re-exports them from `par-term-config`
- Replaces local type definitions in `src/pane/types.rs` and `src/tab/mod.rs` with `pub use par_term_config::{PaneId, TabId}` re-exports for full backward compatibility
- Updates `src/tmux/sync.rs` to import `PaneId` and `TabId` directly from `par_term_config`, removing the last internal crate coupling that blocked tmux subcrate extraction

## Test plan

- [x] `make build` succeeds (all crates compile)
- [x] `make test` passes (387+ tests, 0 failures)
- [x] Backward-compatible: all existing call sites continue to work via re-exports

Closes #183
Blocks resolved for #184 (par-term-tmux subcrate extraction)