### PR TITLE
fix(error): print error message on startup failure

### DIFF
--- a/src/tab_bar_ui.rs
+++ b/src/tab_bar_ui.rs
@@ -1984,7 +1984,7 @@ fn regional_indicator_to_ascii(ch: char) -> Option<char> {
         return None;
     }
     let offset = (ch as u32) - 0x1F1E6;
-    Some(char::from_u32(u32::from(b'A') + offset)?)
+    char::from_u32(u32::from(b'A') + offset)
 }
 
 /// SMP pictographs (most "emoji-only" symbols) commonly fail in egui's font stack.


### PR DESCRIPTION
## Summary

- When par-term fails to start (e.g., no X or Wayland display server found), the error was silently discarded — the process exited with code 1 but printed nothing to stderr
- Now the error is printed via `eprintln!` so users see what went wrong
- On Linux, if the error text suggests a missing display server (contains keywords like `display`, `wayland`, `xcb`, etc.), an additional actionable hint is printed pointing to `DISPLAY`/`WAYLAND_DISPLAY`
- Also fixes a pre-existing `clippy::needless_question_mark` warning in `tab_bar_ui.rs`

Closes #197

## Test plan

- [ ] Build passes (`make build`)
- [ ] All tests pass (`make test`)
- [ ] Lint passes (`make lint`)
- [ ] On Linux without a display server set, running `par-term` now shows a meaningful error message and hint instead of silently exiting with code 1